### PR TITLE
User scraper

### DIFF
--- a/Kragle/Kragle/FileStore.cs
+++ b/Kragle/Kragle/FileStore.cs
@@ -201,7 +201,7 @@ namespace Kragle
         /// <returns>the absolute path to the directory and file</returns>
         private string GetAbsolutePath(string directory, string file = "")
         {
-            return _rootDir.FullName + "/" + directory + "/" + file;
+            return Path.GetFullPath(_rootDir.FullName + "/" + directory + "/" + file);
         }
 
         /// <summary>

--- a/Kragle/Kragle/Kragle.csproj
+++ b/Kragle/Kragle/Kragle.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Scraper.cs" />
+    <Compile Include="UserScraper.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/Kragle/Kragle/Program.cs
+++ b/Kragle/Kragle/Program.cs
@@ -56,6 +56,11 @@ namespace Kragle
                 case "users":
                 {
                     UsersSubOptions subOptions = (UsersSubOptions) _invokedVerbInstance;
+
+                    FileStore fs = new FileStore(subOptions.Path);
+                    UserScraper scraper = new UserScraper(fs, subOptions.Count, subOptions.NoCache);
+                    scraper.Scrape();
+
                     break;
                 }
 

--- a/Kragle/Kragle/Program.cs
+++ b/Kragle/Kragle/Program.cs
@@ -168,7 +168,7 @@ namespace Kragle
     /// </summary>
     internal class UsersSubOptions : FileSystemSharedOptions
     {
-        [Option('n', "number", HelpText = "The number of users to scrape")]
+        [Option('n', "number", DefaultValue = int.MaxValue, HelpText = "The number of users to scrape")]
         public int Count { get; set; }
 
         [Option('m', "meta", HelpText = "Download user meta-data")]

--- a/Kragle/Kragle/Program.cs
+++ b/Kragle/Kragle/Program.cs
@@ -59,7 +59,12 @@ namespace Kragle
 
                     FileStore fs = new FileStore(subOptions.Path);
                     UserScraper scraper = new UserScraper(fs, subOptions.Count, subOptions.NoCache);
-                    scraper.Scrape();
+
+                    scraper.ScrapeUsers();
+                    if (subOptions.Meta)
+                    {
+                        scraper.DownloadMetaData();
+                    }
 
                     break;
                 }
@@ -134,6 +139,9 @@ namespace Kragle
 
         [Option('c', "nocache", HelpText = "Disable caching; slows down the process significantly")]
         public bool NoCache { get; set; }
+
+        [Option('m', "meta", HelpText = "Download user meta-data")]
+        public bool Meta { get; set; }
     }
 
     /// <summary>

--- a/Kragle/Kragle/Scraper.cs
+++ b/Kragle/Kragle/Scraper.cs
@@ -26,11 +26,11 @@ namespace Kragle
 
 
         /// <summary>
-        ///     Fetches JSON from the given URL and returns the serialised string.
+        ///     Fetches the contents from the given URL as a string.
         /// </summary>
-        /// <param name="url">the valid url to fetch the JSON from</param>
-        /// <returns>a deserialised JSON object, or <code>null</code> if the JSON could not be deserialised</returns>
-        protected dynamic GetJson(string url)
+        /// <param name="url">the valid url to fetch the contents from</param>
+        /// <returns>the contents of the webpage, or <code>null</code> if the url could not be accessed</returns>
+        protected string GetContents(string url)
         {
             if (!Uri.IsWellFormedUriString(url, UriKind.Absolute))
             {
@@ -38,12 +38,12 @@ namespace Kragle
             }
 
             // Download webpage contents
-            string rawJson;
+            string contents;
             using (WebClient client = new WebClient())
             {
                 try
                 {
-                    rawJson = client.DownloadString(AppendRandomParameter(url));
+                    contents = client.DownloadString(AppendRandomParameter(url));
                 }
                 catch (WebException e)
                 {
@@ -51,6 +51,18 @@ namespace Kragle
                     return null;
                 }
             }
+
+            return contents;
+        }
+
+        /// <summary>
+        ///     Fetches JSON from the given URL.
+        /// </summary>
+        /// <param name="url">the valid url to fetch the JSON from</param>
+        /// <returns>a deserialised JSON object, or <code>null</code> if the JSON could not be deserialised</returns>
+        protected dynamic GetJson(string url)
+        {
+            string rawJson = GetContents(url);
 
             // Verify parsability
             try

--- a/Kragle/Kragle/Scraper.cs
+++ b/Kragle/Kragle/Scraper.cs
@@ -16,7 +16,7 @@ namespace Kragle
 
 
         /// <summary>
-        ///     Constructs a new Scraper.
+        ///     Constructs a new <code>Scraper</code>.
         /// </summary>
         /// <param name="noCache">true if requests should be made without using the cache in requests</param>
         public Scraper(bool noCache)

--- a/Kragle/Kragle/UserScraper.cs
+++ b/Kragle/Kragle/UserScraper.cs
@@ -12,9 +12,9 @@ namespace Kragle
     {
         private const string SubDirectory = "users";
         private const int PageSize = 20;
+        private readonly Downloader _downloader;
 
         private readonly FileStore _fs;
-        private readonly Downloader _downloader;
         private readonly int _targetUserCount;
 
 
@@ -63,6 +63,10 @@ namespace Kragle
                     // Add user
                     _fs.WriteFile(SubDirectory, fileName, "");
                     userCount++;
+                    if (userCount >= _targetUserCount)
+                    {
+                        break;
+                    }
                 }
 
                 Console.WriteLine(userCount + " / " + _targetUserCount + " users\n");
@@ -71,7 +75,8 @@ namespace Kragle
         }
 
         /// <summary>
-        ///     Downloads meta-data for all users. If the <code>noCache</code> attribute is set, existing meta-data is updated.
+        ///     Downloads meta-data for all users. If the <code>noCache</code> attribute is set, existing meta-data is
+        ///     updated.
         /// </summary>
         public void DownloadMetaData()
         {
@@ -124,7 +129,7 @@ namespace Kragle
         }
 
         /// <summary>
-        /// Downloads meta-data on a user.
+        ///     Downloads meta-data on a user.
         /// </summary>
         /// <param name="username">the user's username</param>
         /// <returns>the meta-data on the user</returns>

--- a/Kragle/Kragle/UserScraper.cs
+++ b/Kragle/Kragle/UserScraper.cs
@@ -37,27 +37,35 @@ namespace Kragle
             int pageNumber = 0;
             int userCount = _fs.GetFiles(SubDirectory).Length;
 
+            Console.WriteLine("Starting user scraping...\n" +
+                              userCount + " users already registered.\n\n");
+
             // Keep downloading projects until the target has been reached
             while (userCount < _targetUserCount)
             {
+                Console.WriteLine("Downloading page " + pageNumber);
                 ICollection<dynamic> projects = GetRecentProjects(pageNumber, PageSize);
 
                 // Loop over projects
                 foreach (dynamic project in projects)
                 {
+                    Console.Write("  User " + project.author.id + "... ");
                     string fileName = project.author.id + ".json";
 
                     // Skip project if user is already known
                     if (_fs.FileExists(SubDirectory, fileName))
                     {
+                        Console.WriteLine("skipped");
                         continue;
                     }
 
                     // Add user
+                    Console.WriteLine("added");
                     _fs.WriteFile(SubDirectory, fileName, "");
                     userCount++;
                 }
 
+                Console.WriteLine(userCount + " / " + _targetUserCount + " users\n");
                 pageNumber++;
             }
         }

--- a/Kragle/Kragle/UserScraper.cs
+++ b/Kragle/Kragle/UserScraper.cs
@@ -121,13 +121,15 @@ namespace Kragle
             return projects;
         }
 
-        //
+        /// <summary>
+        /// Downloads meta-data on a user.
+        /// </summary>
+        /// <param name="username">the user's username</param>
+        /// <returns>the meta-data on the user</returns>
         protected string GetMetaData(string username)
         {
             const string url = "https://api.scratch.mit.edu/users/{0}";
-            dynamic metaData = GetJson(string.Format(url, username));
-
-            return metaData.ToString();
+            return GetContents(string.Format(url, username));
         }
     }
 }

--- a/Kragle/Kragle/UserScraper.cs
+++ b/Kragle/Kragle/UserScraper.cs
@@ -24,7 +24,7 @@ namespace Kragle
         /// <param name="fs">the <code>FileStore</code> to use to access the filesystem</param>
         /// <param name="downloader">the <code>Downloader</code> to download user data with</param>
         /// <param name="targetUserCount">the target number of scraped users</param>
-        public UserScraper(FileStore fs, Downloader downloader, int targetUserCount = int.MaxValue)
+        public UserScraper(FileStore fs, Downloader downloader, int targetUserCount)
         {
             _fs = fs;
             _downloader = downloader;

--- a/Kragle/Kragle/UserScraper.cs
+++ b/Kragle/Kragle/UserScraper.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+
+
+namespace Kragle
+{
+    /// <summary>
+    ///     A scraper that scrapes the list of most recent users.
+    /// </summary>
+    public class UserScraper : Scraper
+    {
+        public UserScraper(bool noCache) : base(noCache)
+        {
+        }
+
+
+        /// <summary>
+        ///     Returns the <code>ICollection</code> of most recently published projects. The results are returned as pages.
+        /// </summary>
+        /// <param name="pageNumber">the number of the page to return; must be at least 0</param>
+        /// <param name="pageSize">the number of projects per page; must be between 1 and 20 (inclusive)</param>
+        /// <returns>the <code>ICollection</code> of most recently published projects</returns>
+        protected ICollection<dynamic> GetRecentProjects(int pageNumber, int pageSize)
+        {
+            if (pageNumber < 0)
+            {
+                throw new ArgumentException("The page number must be at least 0.");
+            }
+            if (pageSize < 1 || pageSize > 20)
+            {
+                throw new ArgumentException("The page size must be between 1 and 20 (inclusive).");
+            }
+
+            // Fetch JSON
+            const string url = "https://api.scratch.mit.edu/search/projects?mode=recent&offset={0}&limit={1}";
+            dynamic projectList = GetJson(string.Format(url, pageNumber, pageSize));
+
+            // Parse to collection
+            ICollection<dynamic> projects = new List<dynamic>(pageSize);
+            foreach (dynamic project in projectList)
+            {
+                projects.Add(project);
+            }
+
+            return projects;
+        }
+    }
+}

--- a/Kragle/KragleTests/KragleTests.csproj
+++ b/Kragle/KragleTests/KragleTests.csproj
@@ -55,6 +55,7 @@
     <Compile Include="FileStoreTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ScraperTests.cs" />
+    <Compile Include="UserScraperTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Kragle\Kragle.csproj">

--- a/Kragle/KragleTests/KragleTests.csproj
+++ b/Kragle/KragleTests/KragleTests.csproj
@@ -37,6 +37,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
   </ItemGroup>
   <Choose>
@@ -62,6 +66,9 @@
       <Project>{BAB35749-6034-41CC-99E6-63253DD29922}</Project>
       <Name>Kragle</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/Kragle/KragleTests/ScraperTests.cs
+++ b/Kragle/KragleTests/ScraperTests.cs
@@ -17,6 +17,32 @@ namespace KragleTests
 
 
         [TestMethod]
+        public void GetContentsInvalidUrlTest()
+        {
+            const string url = "http://invalid-url.net/";
+
+            Assert.IsNull(GetContents(url));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void GetContentsMalformedUrlTest()
+        {
+            const string url = "qABkq6C0oi";
+
+            GetContents(url);
+        }
+
+        [TestMethod]
+        public void GetContentsValidTest()
+        {
+            const string url = "https://jsonplaceholder.typicode.com/posts";
+
+            Assert.IsNotNull(GetContents(url));
+        }
+
+
+        [TestMethod]
         public void GetJsonUnparsableTest()
         {
             const string url = "https://www.google.com/";
@@ -48,6 +74,7 @@ namespace KragleTests
 
             Assert.IsNotNull(GetJson(url));
         }
+
 
         [TestMethod]
         public void AppendRandomParameterStartsWithTest()

--- a/Kragle/KragleTests/UserScraperTests.cs
+++ b/Kragle/KragleTests/UserScraperTests.cs
@@ -10,7 +10,7 @@ namespace KragleTests
     [TestClass]
     public class UserScraperTests : UserScraper
     {
-        public UserScraperTests() : base(new FileStore(), new Downloader(true))
+        public UserScraperTests() : base(new FileStore(), new Downloader(true), int.MaxValue)
         {
         }
 

--- a/Kragle/KragleTests/UserScraperTests.cs
+++ b/Kragle/KragleTests/UserScraperTests.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using Kragle;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+
+namespace KragleTests
+{
+    [TestClass]
+    public class UserScraperTests : UserScraper
+    {
+        public UserScraperTests() : base(false)
+        {
+        }
+
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void UserScraperNegativePageTest()
+        {
+            GetRecentProjects(-3, 14);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void UserScraperExcessiveSizeTest()
+        {
+            GetRecentProjects(28, 94);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void UserScraperInsufficientSizeTest()
+        {
+            GetRecentProjects(12, -38);
+        }
+
+        [TestMethod]
+        public void UserScraperSizeTest()
+        {
+            ICollection<dynamic> projects = GetRecentProjects(98, 14);
+
+            Assert.AreEqual(14, projects.Count);
+        }
+    }
+}

--- a/Kragle/KragleTests/UserScraperTests.cs
+++ b/Kragle/KragleTests/UserScraperTests.cs
@@ -9,7 +9,7 @@ namespace KragleTests
     [TestClass]
     public class UserScraperTests : UserScraper
     {
-        public UserScraperTests() : base(false)
+        public UserScraperTests() : base(new FileStore())
         {
         }
 

--- a/Kragle/KragleTests/UserScraperTests.cs
+++ b/Kragle/KragleTests/UserScraperTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Kragle;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 
 
 namespace KragleTests
@@ -16,31 +17,47 @@ namespace KragleTests
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
-        public void UserScraperNegativePageTest()
+        public void UserScraperRecentProjectsNegativePageTest()
         {
             GetRecentProjects(-3, 14);
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
-        public void UserScraperExcessiveSizeTest()
+        public void UserScraperRecentProjectsExcessiveSizeTest()
         {
             GetRecentProjects(28, 94);
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
-        public void UserScraperInsufficientSizeTest()
+        public void UserScraperRecentProjectsInsufficientSizeTest()
         {
             GetRecentProjects(12, -38);
         }
 
         [TestMethod]
-        public void UserScraperSizeTest()
+        public void UserScraperRecentProjectsSizeTest()
         {
             ICollection<dynamic> projects = GetRecentProjects(98, 14);
 
             Assert.AreEqual(14, projects.Count);
+        }
+
+
+        [TestMethod]
+        public void UserScraperMetaDataInvalidNameTest()
+        {
+            // Names must be at least three characters long
+            Assert.IsNull(GetMetaData("1"));
+        }
+
+        [TestMethod]
+        public void UserScraperMetaDataTest()
+        {
+            dynamic metaData = JsonConvert.DeserializeObject(GetMetaData("kragle_user"));
+
+            Assert.AreEqual("kragle_user", metaData.username.ToString());
         }
     }
 }

--- a/Kragle/KragleTests/packages.config
+++ b/Kragle/KragleTests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
+</packages>


### PR DESCRIPTION
**This PR indirectly also contains PR #6, as it continues on the functionality in that PR. PR #6 should be merged before this PR.**

This PR introduces the `UserScraper` class, which scrapes the list of most recently updated projects and finds the users who uploaded these projects. For each of these users, a file named after the user's username is created.

The user scraping functionality is launched using the `user` verb command, and has a few possible options:
* `-n` gives the number of users that should be downloaded. If there are already downloaded users, this number is the total number of users that should be present afterwards. That is, if there are 40 users present, `-n200` will download 160 additional users.
* `-m` indicates the metadata on the users should be downloaded, which includes their date and time of registration, country of residence, etc.
