### PR TITLE
Project scraper

### DIFF
--- a/Kragle/Kragle/Downloader.cs
+++ b/Kragle/Kragle/Downloader.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Net;
+using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 
 
@@ -29,8 +30,9 @@ namespace Kragle
         ///     Fetches the contents from the given URL as a string.
         /// </summary>
         /// <param name="url">the valid url to fetch the contents from</param>
+        /// <param name="minify">true if the returned string should be stripped of unnecessary spaces</param>
         /// <returns>the contents of the webpage, or <code>null</code> if the url could not be accessed</returns>
-        public string GetContents(string url)
+        public string GetContents(string url, bool minify = false)
         {
             if (!Uri.IsWellFormedUriString(url, UriKind.Absolute))
             {
@@ -53,6 +55,11 @@ namespace Kragle
                 }
             }
 
+            if (minify)
+            {
+                // Strip unnecessary whitespace
+                Regex.Replace(contents, "(\"(?:[^\"\\\\]|\\\\.)*\")|\\s+", "$1");
+            }
             return contents;
         }
 

--- a/Kragle/Kragle/Downloader.cs
+++ b/Kragle/Kragle/Downloader.cs
@@ -2,7 +2,7 @@
 using System.IO;
 using System.Net;
 using System.Text.RegularExpressions;
-using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 
 namespace Kragle
@@ -25,6 +25,25 @@ namespace Kragle
             _noCache = noCache;
         }
 
+
+        /// <summary>
+        ///     Validates JSON.
+        /// </summary>
+        /// <param name="json">a JSON string</param>
+        /// <returns>true if the given JSON is valid</returns>
+        public static bool IsValidJson(string json)
+        {
+            try
+            {
+                JToken.Parse(json);
+            }
+            catch (Exception e)
+            {
+                return false;
+            }
+
+            return true;
+        }
 
         /// <summary>
         ///     Fetches the contents from the given URL as a string.
@@ -68,14 +87,13 @@ namespace Kragle
         /// </summary>
         /// <param name="url">the valid url to fetch the JSON from</param>
         /// <returns>a deserialised JSON object, or <code>null</code> if the JSON could not be deserialised</returns>
-        public dynamic GetJson(string url)
+        public JToken GetJson(string url)
         {
             string rawJson = GetContents(url);
 
-            // Verify parsability
             try
             {
-                return JsonConvert.DeserializeObject(rawJson);
+                return JToken.Parse(rawJson);
             }
             catch (Exception)
             {

--- a/Kragle/Kragle/Kragle.csproj
+++ b/Kragle/Kragle/Kragle.csproj
@@ -68,6 +68,7 @@
   <ItemGroup>
     <Compile Include="FileStore.cs" />
     <Compile Include="Program.cs" />
+    <Compile Include="ProjectScraper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Scraper.cs" />
   </ItemGroup>

--- a/Kragle/Kragle/Program.cs
+++ b/Kragle/Kragle/Program.cs
@@ -77,9 +77,14 @@ namespace Kragle
                     FileStore fs = new FileStore(subOptions.Path);
                     ProjectScraper scraper = new ProjectScraper(fs, subOptions.NoCache);
 
-                    scraper.UpdateProjectList();
-                    Console.WriteLine();
-                    scraper.DownloadProjects();
+                    if (subOptions.Update)
+                    {
+                        scraper.UpdateProjectList();
+                    }
+                    if (subOptions.Download)
+                    {
+                        scraper.DownloadProjects();
+                    }
 
                     break;
                 }
@@ -165,6 +170,11 @@ namespace Kragle
     /// </summary>
     internal class ProjectsSubOptions : FileSystemSharedOptions
     {
+        [Option('u', "update", HelpText = "Update the list of registered projects")]
+        public bool Update { get; set; }
+
+        [Option('d', "download", HelpText = "Download project code")]
+        public bool Download { get; set; }
     }
 
     /// <summary>

--- a/Kragle/Kragle/Program.cs
+++ b/Kragle/Kragle/Program.cs
@@ -77,6 +77,8 @@ namespace Kragle
                     FileStore fs = new FileStore(subOptions.Path);
                     ProjectScraper scraper = new ProjectScraper(fs, subOptions.NoCache);
 
+                    scraper.UpdateProjectList();
+                    Console.WriteLine();
                     scraper.DownloadProjects();
 
                     break;

--- a/Kragle/Kragle/Program.cs
+++ b/Kragle/Kragle/Program.cs
@@ -73,6 +73,12 @@ namespace Kragle
                 case "projects":
                 {
                     ProjectsSubOptions subOptions = (ProjectsSubOptions) _invokedVerbInstance;
+
+                    FileStore fs = new FileStore(subOptions.Path);
+                    ProjectScraper scraper = new ProjectScraper(fs, subOptions.NoCache);
+
+                    scraper.DownloadProjects();
+
                     break;
                 }
 
@@ -124,6 +130,9 @@ namespace Kragle
     {
         [Option('p', "path", HelpText = "The path files should be read from and written to")]
         public string Path { get; set; }
+
+        [Option('c', "nocache", HelpText = "Disable caching; slows down the process significantly")]
+        public bool NoCache { get; set; }
     }
 
     /// <summary>
@@ -147,9 +156,6 @@ namespace Kragle
     {
         [Option('n', "number", HelpText = "The number of users to scrape")]
         public int Count { get; set; }
-
-        [Option('c', "nocache", HelpText = "Disable caching; slows down the process significantly")]
-        public bool NoCache { get; set; }
     }
 
     /// <summary>

--- a/Kragle/Kragle/ProjectScraper.cs
+++ b/Kragle/Kragle/ProjectScraper.cs
@@ -61,9 +61,8 @@ namespace Kragle
             foreach (FileInfo project in projects)
             {
                 int projectId = Convert.ToInt32(project.Name);
-                string filename = projectId + " " + DateTime.Now.ToString("yyyy-MM-dd HHmm");
 
-                _fs.WriteFile("code", filename, GetProjectCode(projectId));
+                _fs.WriteFile("code/" + DateTime.Now.ToString("yyyy-MM-dd"), projectId.ToString(), GetProjectCode(projectId));
 
                 projectCurrent++;
                 Console.WriteLine("{0:P2}", projectCurrent / (double) projectTotal);

--- a/Kragle/Kragle/ProjectScraper.cs
+++ b/Kragle/Kragle/ProjectScraper.cs
@@ -15,7 +15,7 @@ namespace Kragle
         ///     Constructs a new <code>ProjectScraper</code>.
         /// </summary>
         /// <param name="fs">the <code>FileStore</code> to use to access the filesystem</param>
-        /// <param name="noCache">true if requests should be made without using the cache in requests</param>
+        /// <param name="downloader">the <code>Downloader</code> to use for downloading data from the API</param>
         public ProjectScraper(FileStore fs, Downloader downloader)
         {
             _fs = fs;

--- a/Kragle/Kragle/ProjectScraper.cs
+++ b/Kragle/Kragle/ProjectScraper.cs
@@ -61,8 +61,9 @@ namespace Kragle
             foreach (FileInfo project in projects)
             {
                 int projectId = Convert.ToInt32(project.Name);
+                string filename = projectId + " " + DateTime.Now.ToString("yyyy-MM-dd HHmm");
 
-                _fs.WriteFile("code", projectId + " 2016-02-04", GetProjectCode(projectId));
+                _fs.WriteFile("code", filename, GetProjectCode(projectId));
 
                 projectCurrent++;
                 Console.WriteLine("{0:P2}", projectCurrent / (double) projectTotal);

--- a/Kragle/Kragle/ProjectScraper.cs
+++ b/Kragle/Kragle/ProjectScraper.cs
@@ -24,11 +24,13 @@ namespace Kragle
         /// <summary>
         ///     Generates files for all projects of all registered users, but does not download project code yet.
         /// </summary>
-        public void DownloadProjects()
+        public void UpdateProjectList()
         {
             FileInfo[] users = _fs.GetFiles("users");
+            int userTotal = users.Length;
+            int userCurrent = 0;
 
-            Console.WriteLine("Downloading project lists for " + users.Length + " users\n\n");
+            Console.WriteLine("Downloading project lists for " + users.Length + " users.");
 
             foreach (FileInfo user in users)
             {
@@ -39,6 +41,31 @@ namespace Kragle
                 {
                     _fs.WriteFile("projects", project.id.ToString(), "");
                 }
+
+                userCurrent++;
+                Console.WriteLine("{0:P2}", userCurrent / (double) userTotal);
+            }
+        }
+
+        /// <summary>
+        ///     Downloads project code for all registered projects.
+        /// </summary>
+        public void DownloadProjects()
+        {
+            FileInfo[] projects = _fs.GetFiles("projects");
+            int projectTotal = projects.Length;
+            int projectCurrent = 0;
+
+            Console.WriteLine("Downloading code for " + projects.Length + " projects.");
+
+            foreach (FileInfo project in projects)
+            {
+                int projectId = Convert.ToInt32(project.Name);
+
+                _fs.WriteFile("code", projectId + " 2016-02-04", GetProjectCode(projectId));
+
+                projectCurrent++;
+                Console.WriteLine("{0:P2}", projectCurrent / (double) projectTotal);
             }
         }
 
@@ -67,6 +94,17 @@ namespace Kragle
             }
 
             return projects;
+        }
+
+        /// <summary>
+        ///     Fetches the current state of a project's code.
+        /// </summary>
+        /// <param name="projectId">the project's id</param>
+        /// <returns>the current state of the code of the project</returns>
+        protected string GetProjectCode(int projectId)
+        {
+            const string url = "http://projects.scratch.mit.edu/internalapi/project/{0}/get/";
+            return GetContents(string.Format(url, projectId));
         }
     }
 }

--- a/Kragle/Kragle/ProjectScraper.cs
+++ b/Kragle/Kragle/ProjectScraper.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+
+
+namespace Kragle
+{
+    public class ProjectScraper : Scraper
+    {
+        private readonly FileStore _fs;
+
+
+        /// <summary>
+        ///     Constructs a new <code>ProjectScraper</code>.
+        /// </summary>
+        /// <param name="fs">the <code>FileStore</code> to use to access the filesystem</param>
+        /// <param name="noCache">true if requests should be made without using the cache in requests</param>
+        public ProjectScraper(FileStore fs, bool noCache) : base(noCache)
+        {
+            _fs = fs;
+        }
+
+
+        /// <summary>
+        ///     Generates files for all projects of all registered users, but does not download project code yet.
+        /// </summary>
+        public void DownloadProjects()
+        {
+            FileInfo[] users = _fs.GetFiles("users");
+
+            Console.WriteLine("Downloading project lists for " + users.Length + " users\n\n");
+
+            foreach (FileInfo user in users)
+            {
+                string userName = user.Name;
+                ICollection<dynamic> projects = GetUserProjects(userName);
+
+                foreach (dynamic project in projects)
+                {
+                    _fs.WriteFile("projects", project.id.ToString(), "");
+                }
+            }
+        }
+
+
+        /// <summary>
+        ///     Downloads the list of projects of the given user.
+        /// </summary>
+        /// <param name="username">the user's username</param>
+        /// <returns>the list of projects of the given user</returns>
+        protected ICollection<dynamic> GetUserProjects(string username)
+        {
+            // Fetch JSON
+            const string url = "https://api.scratch.mit.edu/users/{0}/projects";
+            dynamic projectList = GetJson(string.Format(url, username));
+
+            if (projectList == null)
+            {
+                return null;
+            }
+
+            // Parse to collection
+            ICollection<dynamic> projects = new List<dynamic>();
+            foreach (dynamic project in projectList)
+            {
+                projects.Add(project);
+            }
+
+            return projects;
+        }
+    }
+}

--- a/Kragle/Kragle/ProjectScraper.cs
+++ b/Kragle/Kragle/ProjectScraper.cs
@@ -94,6 +94,11 @@ namespace Kragle
                     }
 
                     string projectCode = GetProjectCode(projectId);
+                    if (projectCode == null)
+                    {
+                        // Code not downloaded for whatever reason
+                        continue;
+                    }
                     if (!Downloader.IsValidJson(projectCode))
                     {
                         // Invalid JSON, no need to save it

--- a/Kragle/Kragle/Scraper.cs
+++ b/Kragle/Kragle/Scraper.cs
@@ -26,11 +26,11 @@ namespace Kragle
 
 
         /// <summary>
-        ///     Fetches JSON from the given URL and returns the serialised string.
+        ///     Fetches the contents from the given URL as a string.
         /// </summary>
-        /// <param name="url">the valid url to fetch the JSON from</param>
-        /// <returns>a deserialised JSON object, or <code>null</code> if the JSON could not be deserialised</returns>
-        protected dynamic GetJson(string url)
+        /// <param name="url">the valid url to fetch the contents from</param>
+        /// <returns>the contents of the webpage, or <code>null</code> if the url could not be accessed</returns>
+        protected string GetContents(string url)
         {
             if (!Uri.IsWellFormedUriString(url, UriKind.Absolute))
             {
@@ -38,12 +38,12 @@ namespace Kragle
             }
 
             // Download webpage contents
-            string rawJson;
+            string contents;
             using (WebClient client = new WebClient())
             {
                 try
                 {
-                    rawJson = client.DownloadString(AppendRandomParameter(url));
+                    contents = client.DownloadString(AppendRandomParameter(url));
                 }
                 catch (WebException e)
                 {
@@ -51,6 +51,18 @@ namespace Kragle
                     return null;
                 }
             }
+
+            return contents;
+        }
+
+        /// <summary>
+        ///     Fetches JSON from the given URL.
+        /// </summary>
+        /// <param name="url">the valid url to fetch the JSON from</param>
+        /// <returns>a deserialised JSON object, or <code>null</code> if the JSON could not be deserialised</returns>
+        protected dynamic GetJson(string url)
+        {
+            string rawJson = GetContents(url);
 
             // Verify parsability
             try

--- a/Kragle/KragleTests/KragleTests.csproj
+++ b/Kragle/KragleTests/KragleTests.csproj
@@ -53,6 +53,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="FileStoreTests.cs" />
+    <Compile Include="ProjectScraperTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ScraperTests.cs" />
   </ItemGroup>

--- a/Kragle/KragleTests/KragleTests.csproj
+++ b/Kragle/KragleTests/KragleTests.csproj
@@ -37,6 +37,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed" />
     <Reference Include="System" />
   </ItemGroup>
   <Choose>

--- a/Kragle/KragleTests/ProjectScraperTests.cs
+++ b/Kragle/KragleTests/ProjectScraperTests.cs
@@ -26,5 +26,17 @@ namespace KragleTests
         {
             Assert.AreEqual(0, GetUserProjects("kragle_user").Count);
         }
+
+        [TestMethod]
+        public void GetProjectCodeNegativeIdTest()
+        {
+            Assert.IsNull(GetProjectCode(-1));
+        }
+
+        [TestMethod]
+        public void GetProjectCodeUnusedIdTest()
+        {
+            Assert.IsNull(GetProjectCode(14));
+        }
     }
 }

--- a/Kragle/KragleTests/ProjectScraperTests.cs
+++ b/Kragle/KragleTests/ProjectScraperTests.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Kragle;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+
+namespace KragleTests
+{
+    [TestClass]
+    public class ProjectScraperTests : ProjectScraper
+    {
+        public ProjectScraperTests() : base(new FileStore(), false)
+        {
+        }
+
+
+        [TestMethod]
+        public void GetUserProjectsInvalidUsernameTest()
+        {
+            // Names must be at least three characters long
+            Assert.IsNull(GetUserProjects("1"));
+        }
+
+        [TestMethod]
+        public void GetUserProjectsValidTest()
+        {
+            Assert.AreEqual(0, GetUserProjects("kragle_user").Count);
+        }
+    }
+}


### PR DESCRIPTION
**This PR indirectly also contains PR #6, as it continues on the functionality in that PR. PR #6 should be merged before this PR.**

This PR introduces the `ProjectScraper` class, which checks the list of downloaded users and downloads their respective lists of projects and the code of each project. For each project, a file named after the project's ID will be created (without contents) with the name `projects/<username>/<project id>`, and for each code instance another file will be created with the name `code/<project id>/<date>`. This specific structure will allow the parser to easily build relational structures between the different data types.
See below for an example of the folder structure.

The project scraping functionality is launched using the `project` verb command, which accepts a few options (which can be combined; the order in which they are given is ignored):
* `-u` updates the list of projects of each registered user. The list of projects of each user is downloaded, and an empty file is created for each project in this list.
* `-d` downloads the code for each registered project.

## Folder structure example
**bold** is a directory, _italic_ is a file.

* **users**
  * _a_username_
  * _another_username_
* **projects**
  * **a_username**
    * _5819020_
    * _6818232_
    * _list_
  * **another_username**
    * _8194996_
    * _list_
* **code**
  * **5819020**
    * _2017-02-16_
    * _2017-02-17_
  * **6818232**
    * _2017-02-16_
    * _2017-02-17_
  * **8194996**
    * _2017-02-16_
    * _2017-02-17_
  * **5819020**
    * _2017-02-16_
    * _2017-02-17_
  * **6818232**
    * _2017-02-16_
    * _2017-02-17_
  * **8194996**
    * _2017-02-16_
    * _2017-02-17_
