### PR TITLE
Logger

### DIFF
--- a/Kragle/Kragle/Downloader.cs
+++ b/Kragle/Kragle/Downloader.cs
@@ -15,6 +15,7 @@ namespace Kragle
     {
         private readonly int _maxDownloadSize;
         private readonly bool _noCache;
+        private readonly Logger _logger;
 
 
         /// <summary>
@@ -29,6 +30,7 @@ namespace Kragle
         {
             _noCache = noCache;
             _maxDownloadSize = maxDownloadSize;
+            _logger = Logger.GetLogger("Downloader");
         }
 
 
@@ -75,7 +77,7 @@ namespace Kragle
                 }
                 catch (WebException e)
                 {
-                    Console.WriteLine("Failed to get JSON: " + e.Message);
+                    _logger.Log("Failed to get JSON: " + e.Message);
                     return null;
                 }
             }

--- a/Kragle/Kragle/Downloader.cs
+++ b/Kragle/Kragle/Downloader.cs
@@ -13,9 +13,9 @@ namespace Kragle
     /// </summary>
     public class Downloader
     {
+        private static readonly Logger Logger = Logger.GetLogger("Downloader");
         private readonly int _maxDownloadSize;
         private readonly bool _noCache;
-        private readonly Logger _logger;
 
 
         /// <summary>
@@ -30,7 +30,6 @@ namespace Kragle
         {
             _noCache = noCache;
             _maxDownloadSize = maxDownloadSize;
-            _logger = Logger.GetLogger("Downloader");
         }
 
 
@@ -77,7 +76,7 @@ namespace Kragle
                 }
                 catch (WebException e)
                 {
-                    _logger.Log("Failed to get JSON: " + e.Message);
+                    Logger.Log("Failed to get JSON: " + e.Message);
                     return null;
                 }
             }

--- a/Kragle/Kragle/FileStore.cs
+++ b/Kragle/Kragle/FileStore.cs
@@ -11,23 +11,29 @@ namespace Kragle
     {
         private const string KraglePath = "/Kragle";
 
-        private readonly DirectoryInfo _rootDir;
+        private static DirectoryInfo _rootDir;
+
+        static FileStore()
+        {
+            Init();
+        }
 
 
         /// <summary>
-        ///     Constructs a new <code>FileStore</code> in the default directory.
+        ///     Sets the root directory for the <code>FileStore</code> to the default directory.
         /// </summary>
-        public FileStore() : this(null)
+        public static void Init()
         {
+            Init(null);
         }
 
         /// <summary>
-        ///     Constructs a new <code>FileStore</code>.
+        ///     Sets the root directory for the <code>FileStore</code>.
         /// </summary>
         /// <param name="rootDir">
         ///     the root directory of the file store, or <code>null</code> for the default directory
         /// </param>
-        public FileStore(string rootDir)
+        public static void Init(string rootDir)
         {
             if (rootDir == null)
             {
@@ -42,9 +48,20 @@ namespace Kragle
         ///     Returns the full path to this <code>FileStore</code>'s root directory.
         /// </summary>
         /// <returns>the full path to this <code>FileStore</code>'s root directory</returns>
-        public string GetRootPath()
+        public static string GetRootPath()
         {
             return _rootDir.FullName;
+        }
+
+        /// <summary>
+        ///     Returns the absolute path to the directory and file.
+        /// </summary>
+        /// <param name="directory">the subdirectory</param>
+        /// <param name="file">the file</param>
+        /// <returns>the absolute path to the directory and file</returns>
+        public static string GetAbsolutePath(string directory, string file = "")
+        {
+            return Path.GetFullPath(_rootDir.FullName + "/" + directory + "/" + file);
         }
 
         /// <summary>
@@ -54,7 +71,7 @@ namespace Kragle
         /// <param name="file">the file to write to</param>
         /// <param name="contents">the new contents for the file</param>
         /// <param name="append"><code>true</code> if the file should be appended rather than overwritten</param>
-        public void WriteFile(string directory, string file, string contents, bool append = false)
+        public static void WriteFile(string directory, string file, string contents, bool append = false)
         {
             CreateDirectory(directory);
             string filePath = GetAbsolutePath(directory, file);
@@ -83,7 +100,7 @@ namespace Kragle
         /// <param name="append">
         ///     should be <code>true</code> if the file should be appended rather than overwritten
         /// </param>
-        public void WriteFile(string file, string contents, bool append = false)
+        public static void WriteFile(string file, string contents, bool append = false)
         {
             WriteFile("./", file, contents, append);
         }
@@ -94,7 +111,7 @@ namespace Kragle
         /// <param name="directory">the subdirectory relative to this <code>FileStore</code>'s root</param>
         /// <param name="file">the name of the file within the directory</param>
         /// <returns>the contents of the file</returns>
-        public string ReadFile(string directory, string file)
+        public static string ReadFile(string directory, string file)
         {
             string filePath = GetAbsolutePath(directory, file);
             if (!File.Exists(filePath))
@@ -110,7 +127,7 @@ namespace Kragle
         /// </summary>
         /// <param name="file">the name of the file within the directory</param>
         /// <returns>the contents of the file</returns>
-        public string ReadFile(string file)
+        public static string ReadFile(string file)
         {
             return ReadFile("./", file);
         }
@@ -121,7 +138,7 @@ namespace Kragle
         /// <param name="directory">the directory the file is in</param>
         /// <param name="file">the filename</param>
         /// <returns><code>true</code> if the specified file exists</returns>
-        public bool FileExists(string directory, string file)
+        public static bool FileExists(string directory, string file)
         {
             return File.Exists(GetAbsolutePath(directory, file));
         }
@@ -131,7 +148,7 @@ namespace Kragle
         /// </summary>
         /// <param name="file">the filename</param>
         /// <returns><code>true</code> if the specified file exists</returns>
-        public bool FileExists(string file)
+        public static bool FileExists(string file)
         {
             return FileExists("./", file);
         }
@@ -141,7 +158,7 @@ namespace Kragle
         /// </summary>
         /// <param name="directory">the directory the file is in</param>
         /// <param name="file">the filename</param>
-        public void RemoveFile(string directory, string file)
+        public static void RemoveFile(string directory, string file)
         {
             try
             {
@@ -161,16 +178,26 @@ namespace Kragle
         ///     Removes the file.
         /// </summary>
         /// <param name="file">the filename</param>
-        public void RemoveFile(string file)
+        public static void RemoveFile(string file)
         {
             RemoveFile("./", file);
+        }
+
+        /// <summary>
+        ///     Creates a new subdirectory.
+        /// </summary>
+        /// <param name="directory">he name of the subdirectory</param>
+        /// <returns>the <code>DirectoryInfo</code> on the new subdirectory</returns>
+        public static DirectoryInfo CreateDirectory(string directory = "./")
+        {
+            return GetDirectory(directory);
         }
 
         /// <summary>
         ///     Returns true if the specified directory exists.
         /// </summary>
         /// <param name="directory">true if the specified directory exists</param>
-        public bool DirectoryExists(string directory)
+        public static bool DirectoryExists(string directory)
         {
             return Directory.Exists(GetAbsolutePath(directory));
         }
@@ -179,7 +206,7 @@ namespace Kragle
         ///     Removes a directory and all the contained files.
         /// </summary>
         /// <param name="directory">a directory</param>
-        public void RemoveDirectory(string directory = "./")
+        public static void RemoveDirectory(string directory = "./")
         {
             try
             {
@@ -196,7 +223,7 @@ namespace Kragle
         /// </summary>
         /// <param name="directory">the name of a subdirectory</param>
         /// <returns>an array of <code>DirectoryInfo</code>s on all subdirectories in the specified (sub)directory</returns>
-        public DirectoryInfo[] GetDirectories(string directory = "./")
+        public static DirectoryInfo[] GetDirectories(string directory = "./")
         {
             return GetDirectory(directory).GetDirectories();
         }
@@ -206,41 +233,20 @@ namespace Kragle
         /// </summary>
         /// <param name="directory">the name of a subdirectory</param>
         /// <returns>an array of <code>FileInfo</code> on all files in the specified (sub)directory</returns>
-        public FileInfo[] GetFiles(string directory = "./")
+        public static FileInfo[] GetFiles(string directory = "./")
         {
             return GetDirectory(directory).GetFiles();
         }
 
 
         /// <summary>
-        ///     Returns the absolute path to the directory and file.
-        /// </summary>
-        /// <param name="directory">the subdirectory</param>
-        /// <param name="file">the file</param>
-        /// <returns>the absolute path to the directory and file</returns>
-        private string GetAbsolutePath(string directory, string file = "")
-        {
-            return Path.GetFullPath(_rootDir.FullName + "/" + directory + "/" + file);
-        }
-
-        /// <summary>
         ///     Returns the <code>DirectoryInfo</code> on the specified subdirectory.
         /// </summary>
         /// <param name="directory">the name of a subdirectory</param>
         /// <returns>the <code>DirectoryInfo</code> on the specified subdirectory</returns>
-        private DirectoryInfo GetDirectory(string directory = "./")
+        private static DirectoryInfo GetDirectory(string directory = "./")
         {
             return Directory.CreateDirectory(GetAbsolutePath(directory));
-        }
-
-        /// <summary>
-        ///     Creates a new subdirectory.
-        /// </summary>
-        /// <param name="directory">he name of the subdirectory</param>
-        /// <returns>the <code>DirectoryInfo</code> on the new subdirectory</returns>
-        private DirectoryInfo CreateDirectory(string directory = "./")
-        {
-            return GetDirectory(directory);
         }
     }
 }

--- a/Kragle/Kragle/Kragle.csproj
+++ b/Kragle/Kragle/Kragle.csproj
@@ -72,6 +72,7 @@
   <ItemGroup>
     <Compile Include="CsvWriter.cs" />
     <Compile Include="FileStore.cs" />
+    <Compile Include="Logger.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="ProjectScraper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Kragle/Kragle/Logger.cs
+++ b/Kragle/Kragle/Logger.cs
@@ -20,9 +20,11 @@ namespace Kragle
 
         static Logger()
         {
-            string logFile = string.Format("log_{0:yyyy-MM-dd hh-mm-ss}.log", DateTime.Now);
-            string logDir = new FileStore().GetRootPath();
-            FileStream = new StreamWriter(logDir + "/" + logFile);
+            FileStore.CreateDirectory("log");
+
+            string logFile = FileStore.GetAbsolutePath("log",
+                string.Format("log_{0:yyyy-MM-dd hh-mm-ss}.log", DateTime.Now));
+            FileStream = new StreamWriter(logFile);
         }
 
 

--- a/Kragle/Kragle/Logger.cs
+++ b/Kragle/Kragle/Logger.cs
@@ -20,9 +20,11 @@ namespace Kragle
 
         static Logger()
         {
-            string logFile = string.Format("log_{0:yyyyMMMMddhhmmss}.log", DateTime.Now);
-            FileStream = new StreamWriter(logFile);
+            string logFile = string.Format("log_{0:yyyy-MM-dd hh-mm-ss}.log", DateTime.Now);
+            string logDir = new FileStore().GetRootPath();
+            FileStream = new StreamWriter(logDir + "/" + logFile);
         }
+
 
         /// <summary>
         ///     Constructs a new <code>Logger</code>. This logger only writes to the console output, not to a file.

--- a/Kragle/Kragle/Logger.cs
+++ b/Kragle/Kragle/Logger.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 
 
@@ -7,71 +8,94 @@ namespace Kragle
     /// <summary>
     ///     A logger that logs to the console output and to a file. Objects of this class should be treated as if they
     ///     were a stream to the log file, where the <code>Log</code> and <code>LogLine</code> methods incidentally also
-    ///     calll <code>Console.Write</code> or <code>Console.WriteLine</code> methods, respectively.
+    ///     calll <code>EnableConsole.Write</code> or <code>EnableConsole.WriteLine</code> methods, respectively.
     /// </summary>
-    public class Logger : IDisposable
+    public class Logger
     {
-        private readonly StreamWriter _output;
-        private bool _autoFlush = true;
-        private bool _console = true;
+        private static readonly Dictionary<string, Logger> Loggers = new Dictionary<string, Logger>();
+        private static readonly object SyncLock = new object();
+        private static readonly StreamWriter FileStream;
 
+        public readonly string Name;
+
+        static Logger()
+        {
+            string logFile = string.Format("log_{0:yyyyMMMMddhhmmss}.log", DateTime.Now);
+            FileStream = new StreamWriter(logFile);
+        }
 
         /// <summary>
         ///     Constructs a new <code>Logger</code>. This logger only writes to the console output, not to a file.
         /// </summary>
-        public Logger()
+        private Logger(string name)
         {
-            _output = null;
+            Name = name;
         }
 
-        /// <summary>
-        ///     Constructs a new <code>Logger</code> that writes to both the console output and the given file.
-        /// </summary>
-        /// <param name="output">the path to the file to write the log to</param>
-        public Logger(string output)
+        public override bool Equals(object obj)
         {
-            _output = new StreamWriter(output) {AutoFlush = false};
-        }
-
-        /// <summary>
-        ///     The <code>Logger</code> writes to the console output if and only if this value is set to
-        ///     <code>true</code>; calls to <code>Log</code> and <code>LogLine</code> are simply ignored, not
-        ///     buffered.
-        ///     Defaults to <code>true</code>.
-        /// </summary>
-        public bool Console
-        {
-            get { return _console; }
-            set { _console = value; }
-        }
-
-        /// <summary>
-        ///     If set to <code>true</code>, each call to <code>Log</code> or <code>LogLine</code> will also
-        ///     initiate a call to <code>Flush</code>. If set to <code>false</code>, it is guaranteed that the file
-        ///     stream does not automatically flush; the console output stream may still automatically flush depending
-        ///     on its own setting.
-        ///     Setting this field to <code>true</code> will also directly call <code>Flush</code>.
-        ///     Defaults to <code>true</code>.
-        /// </summary>
-        public bool AutoFlush
-        {
-            get { return _autoFlush; }
-            set
+            if (obj == null || GetType() != obj.GetType())
             {
-                _autoFlush = value;
-                if (value)
+                return false;
+            }
+
+            return Name == ((Logger) obj).Name;
+        }
+
+        public override int GetHashCode()
+        {
+            return Name.GetHashCode();
+        }
+
+        /// <summary>
+        ///     Returns the <code>Logger</code> instance with the given name.
+        /// </summary>
+        /// <param name="name">the name of the <code>Logger</code> to return</param>
+        /// <returns>the <code>Logger</code> instance with the given name</returns>
+        public static Logger GetLogger(string name = "")
+        {
+            lock (SyncLock)
+            {
+                if (!Loggers.ContainsKey(name))
                 {
-                    Flush();
+                    Loggers.Add(name, new Logger(name));
                 }
+
+                return Loggers[name];
             }
         }
 
 
-        public void Dispose()
+        /// <summary>
+        ///     Logs a string.
+        /// </summary>
+        /// <param name="name">the name of the logging <code>Logger</code></param>
+        /// <param name="text">a string</param>
+        private static void Log(string name, string text)
         {
-            if (_output != null)
+            string logText = name == ""
+                ? string.Format("[{0}] [{1}] {2}\n", DateTime.Now, name, text)
+                : string.Format("[{0}] {1}\n", DateTime.Now, text);
+
+            Console.Write(logText);
+            if (FileStream != null)
             {
-                _output.Dispose();
+                FileStream.Write(logText);
+            }
+
+            Flush();
+        }
+
+        /// <summary>
+        ///     Flushes the console (if the <code>EnableConsole</code> field is set to <code>true</code>) and the file stream
+        ///     (if there is one).
+        /// </summary>
+        private static void Flush()
+        {
+            Console.Out.Flush();
+            if (FileStream != null)
+            {
+                FileStream.Flush();
             }
         }
 
@@ -80,53 +104,9 @@ namespace Kragle
         ///     Logs a string.
         /// </summary>
         /// <param name="text">a string</param>
-        /// <returns>this <code>Logger</code></returns>
-        public Logger Log(string text)
+        public void Log(string text)
         {
-            if (Console)
-            {
-                System.Console.Write(text);
-            }
-            if (_output != null)
-            {
-                _output.Write(text);
-            }
-
-            if (AutoFlush)
-            {
-                Flush();
-            }
-
-            return this;
-        }
-
-        /// <summary>
-        ///     Logs a string and appends a newline.
-        /// </summary>
-        /// <param name="text">a string</param>
-        /// <returns>this <code>Logger</code></returns>
-        public Logger LogLine(string text)
-        {
-            return Log(text + Environment.NewLine);
-        }
-
-        /// <summary>
-        ///     Flushes the console (if the <code>Console</code> field is set to <code>true</code>) and the file stream
-        ///     (if there is one).
-        /// </summary>
-        /// <returns>this <code>Logger</code></returns>
-        public Logger Flush()
-        {
-            if (Console)
-            {
-                System.Console.Out.Flush();
-            }
-            if (_output != null)
-            {
-                _output.Flush();
-            }
-
-            return this;
+            Log(Name, text);
         }
     }
 }

--- a/Kragle/Kragle/Logger.cs
+++ b/Kragle/Kragle/Logger.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.IO;
+
+
+namespace Kragle
+{
+    /// <summary>
+    ///     A logger that logs to the console output and to a file. Objects of this class should be treated as if they
+    ///     were a stream to the log file, where the <code>Log</code> and <code>LogLine</code> methods incidentally also
+    ///     calll <code>Console.Write</code> or <code>Console.WriteLine</code> methods, respectively.
+    /// </summary>
+    public class Logger : IDisposable
+    {
+        private readonly StreamWriter _output;
+        private bool _autoFlush = true;
+        private bool _console = true;
+
+
+        /// <summary>
+        ///     Constructs a new <code>Logger</code>. This logger only writes to the console output, not to a file.
+        /// </summary>
+        public Logger()
+        {
+            _output = null;
+        }
+
+        /// <summary>
+        ///     Constructs a new <code>Logger</code> that writes to both the console output and the given file.
+        /// </summary>
+        /// <param name="output">the path to the file to write the log to</param>
+        public Logger(string output)
+        {
+            _output = new StreamWriter(output) {AutoFlush = false};
+        }
+
+        /// <summary>
+        ///     The <code>Logger</code> writes to the console output if and only if this value is set to
+        ///     <code>true</code>; calls to <code>Log</code> and <code>LogLine</code> are simply ignored, not
+        ///     buffered.
+        ///     Defaults to <code>true</code>.
+        /// </summary>
+        public bool Console
+        {
+            get { return _console; }
+            set { _console = value; }
+        }
+
+        /// <summary>
+        ///     If set to <code>true</code>, each call to <code>Log</code> or <code>LogLine</code> will also
+        ///     initiate a call to <code>Flush</code>. If set to <code>false</code>, it is guaranteed that the file
+        ///     stream does not automatically flush; the console output stream may still automatically flush depending
+        ///     on its own setting.
+        ///     Setting this field to <code>true</code> will also directly call <code>Flush</code>.
+        ///     Defaults to <code>true</code>.
+        /// </summary>
+        public bool AutoFlush
+        {
+            get { return _autoFlush; }
+            set
+            {
+                _autoFlush = value;
+                if (value)
+                {
+                    Flush();
+                }
+            }
+        }
+
+
+        public void Dispose()
+        {
+            if (_output != null)
+            {
+                _output.Dispose();
+            }
+        }
+
+
+        /// <summary>
+        ///     Logs a string.
+        /// </summary>
+        /// <param name="text">a string</param>
+        /// <returns>this <code>Logger</code></returns>
+        public Logger Log(string text)
+        {
+            if (Console)
+            {
+                System.Console.Write(text);
+            }
+            if (_output != null)
+            {
+                _output.Write(text);
+            }
+
+            if (AutoFlush)
+            {
+                Flush();
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        ///     Logs a string and appends a newline.
+        /// </summary>
+        /// <param name="text">a string</param>
+        /// <returns>this <code>Logger</code></returns>
+        public Logger LogLine(string text)
+        {
+            return Log(text + Environment.NewLine);
+        }
+
+        /// <summary>
+        ///     Flushes the console (if the <code>Console</code> field is set to <code>true</code>) and the file stream
+        ///     (if there is one).
+        /// </summary>
+        /// <returns>this <code>Logger</code></returns>
+        public Logger Flush()
+        {
+            if (Console)
+            {
+                System.Console.Out.Flush();
+            }
+            if (_output != null)
+            {
+                _output.Flush();
+            }
+
+            return this;
+        }
+    }
+}

--- a/Kragle/Kragle/Program.cs
+++ b/Kragle/Kragle/Program.cs
@@ -13,7 +13,6 @@ namespace Kragle
     {
         private static string _invokedVerb;
         private static object _invokedVerbInstance;
-        private static readonly Logger Logger = Logger.GetLogger("Program");
 
 
         /// <summary>
@@ -44,17 +43,17 @@ namespace Kragle
                 case "reset":
                 {
                     ResetSubOptions subOptions = (ResetSubOptions) _invokedVerbInstance;
+                    FileStore.Init(subOptions.Path);
 
                     Console.Write("Remove all users, projects, and code? (y/n)");
                     string confirm = Console.ReadLine();
 
                     if (confirm != null && confirm.ToLower() == "y")
                     {
-                        FileStore fs = new FileStore(subOptions.Path);
-                        fs.RemoveDirectory("users");
-                        fs.RemoveDirectory("projects");
-                        fs.RemoveDirectory("code");
-                        Logger.Log("Removed all users, projects, and code.");
+                        FileStore.RemoveDirectory("users");
+                        FileStore.RemoveDirectory("projects");
+                        FileStore.RemoveDirectory("code");
+                        Console.WriteLine("Removed all users, projects, and code.");
                     }
                     else
                     {
@@ -68,8 +67,9 @@ namespace Kragle
                 case "open":
                 {
                     OpenSubOptions subOptions = (OpenSubOptions) _invokedVerbInstance;
+                    FileStore.Init(subOptions.Path);
 
-                    Process.Start(new FileStore(subOptions.Path).GetRootPath());
+                    Process.Start(FileStore.GetRootPath());
 
                     Environment.Exit(0); // Suppress exit message
                     break;
@@ -78,11 +78,11 @@ namespace Kragle
                 case "users":
                 {
                     UsersSubOptions subOptions = (UsersSubOptions) _invokedVerbInstance;
+                    FileStore.Init(subOptions.Path);
 
-                    FileStore fs = new FileStore(subOptions.Path);
                     Downloader downloader = new Downloader(subOptions.NoCache);
 
-                    UserScraper scraper = new UserScraper(fs, downloader, subOptions.Count);
+                    UserScraper scraper = new UserScraper(downloader, subOptions.Count);
                     scraper.ScrapeUsers();
                     if (subOptions.Meta)
                     {
@@ -95,11 +95,11 @@ namespace Kragle
                 case "projects":
                 {
                     ProjectsSubOptions subOptions = (ProjectsSubOptions) _invokedVerbInstance;
+                    FileStore.Init(subOptions.Path);
 
-                    FileStore fs = new FileStore(subOptions.Path);
                     Downloader downloader = new Downloader(subOptions.NoCache);
 
-                    ProjectScraper scraper = new ProjectScraper(fs, downloader);
+                    ProjectScraper scraper = new ProjectScraper(downloader);
                     if (subOptions.Update)
                     {
                         scraper.UpdateProjectList();
@@ -120,7 +120,7 @@ namespace Kragle
             }
 
             // Exit message
-            Logger.Log("Done.");
+            Console.WriteLine("Done.");
         }
     }
 

--- a/Kragle/Kragle/Program.cs
+++ b/Kragle/Kragle/Program.cs
@@ -13,7 +13,7 @@ namespace Kragle
     {
         private static string _invokedVerb;
         private static object _invokedVerbInstance;
-        private static readonly Logger _logger = Logger.GetLogger("Program");
+        private static readonly Logger Logger = Logger.GetLogger("Program");
 
 
         /// <summary>
@@ -46,8 +46,10 @@ namespace Kragle
                     ResetSubOptions subOptions = (ResetSubOptions) _invokedVerbInstance;
 
                     FileStore fs = new FileStore(subOptions.Path);
-                    fs.RemoveDirectory();
-                    _logger.Log("Removed all files.");
+                    fs.RemoveDirectory("users");
+                    fs.RemoveDirectory("projects");
+                    fs.RemoveDirectory("code");
+                    Logger.Log("Removed all users, projects, and code.");
 
                     break;
                 }
@@ -107,7 +109,7 @@ namespace Kragle
             }
 
             // Exit message
-            _logger.Log("Done.");
+            Logger.Log("Done.");
         }
     }
 

--- a/Kragle/Kragle/Program.cs
+++ b/Kragle/Kragle/Program.cs
@@ -67,8 +67,9 @@ namespace Kragle
 
                     FileStore fs = new FileStore(subOptions.Path);
                     Downloader downloader = new Downloader(subOptions.NoCache);
-                    UserScraper scraper = new UserScraper(fs, downloader, subOptions.Count);
+                    Logger logger = new Logger("logger.log");
 
+                    UserScraper scraper = new UserScraper(fs, downloader, logger, subOptions.Count);
                     scraper.ScrapeUsers();
                     if (subOptions.Meta)
                     {
@@ -84,8 +85,9 @@ namespace Kragle
 
                     FileStore fs = new FileStore(subOptions.Path);
                     Downloader downloader = new Downloader(subOptions.NoCache);
-                    ProjectScraper scraper = new ProjectScraper(fs, downloader);
+                    Logger logger = new Logger("logger.log");
 
+                    ProjectScraper scraper = new ProjectScraper(fs, downloader, logger);
                     if (subOptions.Update)
                     {
                         scraper.UpdateProjectList();

--- a/Kragle/Kragle/Program.cs
+++ b/Kragle/Kragle/Program.cs
@@ -13,6 +13,7 @@ namespace Kragle
     {
         private static string _invokedVerb;
         private static object _invokedVerbInstance;
+        private static readonly Logger _logger = Logger.GetLogger("Program");
 
 
         /// <summary>
@@ -46,7 +47,7 @@ namespace Kragle
 
                     FileStore fs = new FileStore(subOptions.Path);
                     fs.RemoveDirectory();
-                    Console.WriteLine("Removed all files.");
+                    _logger.Log("Removed all files.");
 
                     break;
                 }
@@ -67,9 +68,8 @@ namespace Kragle
 
                     FileStore fs = new FileStore(subOptions.Path);
                     Downloader downloader = new Downloader(subOptions.NoCache);
-                    Logger logger = new Logger("logger.log");
 
-                    UserScraper scraper = new UserScraper(fs, downloader, logger, subOptions.Count);
+                    UserScraper scraper = new UserScraper(fs, downloader, subOptions.Count);
                     scraper.ScrapeUsers();
                     if (subOptions.Meta)
                     {
@@ -85,9 +85,8 @@ namespace Kragle
 
                     FileStore fs = new FileStore(subOptions.Path);
                     Downloader downloader = new Downloader(subOptions.NoCache);
-                    Logger logger = new Logger("logger.log");
 
-                    ProjectScraper scraper = new ProjectScraper(fs, downloader, logger);
+                    ProjectScraper scraper = new ProjectScraper(fs, downloader);
                     if (subOptions.Update)
                     {
                         scraper.UpdateProjectList();
@@ -108,7 +107,7 @@ namespace Kragle
             }
 
             // Exit message
-            Console.WriteLine("\nDone.");
+            _logger.Log("Done.");
         }
     }
 

--- a/Kragle/Kragle/ProjectScraper.cs
+++ b/Kragle/Kragle/ProjectScraper.cs
@@ -10,17 +10,14 @@ namespace Kragle
         private static readonly Logger Logger = Logger.GetLogger("ProjectScraper");
 
         private readonly Downloader _downloader;
-        private readonly FileStore _fs;
 
 
         /// <summary>
         ///     Constructs a new <code>ProjectScraper</code>.
         /// </summary>
-        /// <param name="fs">the <code>FileStore</code> to use to access the filesystem</param>
         /// <param name="downloader">the <code>Downloader</code> to use for downloading data from the API</param>
-        public ProjectScraper(FileStore fs, Downloader downloader)
+        public ProjectScraper(Downloader downloader)
         {
-            _fs = fs;
             _downloader = downloader;
         }
 
@@ -30,7 +27,7 @@ namespace Kragle
         /// </summary>
         public void UpdateProjectList()
         {
-            FileInfo[] users = _fs.GetFiles("users");
+            FileInfo[] users = FileStore.GetFiles("users");
             int userTotal = users.Length;
             int userCurrent = 0;
 
@@ -52,12 +49,12 @@ namespace Kragle
                 }
 
                 // Save list of projects
-                _fs.WriteFile("projects/" + user.Name, "list", projects.ToString());
+                FileStore.WriteFile("projects/" + user.Name, "list", projects.ToString());
 
                 // Create empty files for each project
                 foreach (JToken project in projects)
                 {
-                    _fs.WriteFile("projects/" + user.Name, project["id"].ToString(), "");
+                    FileStore.WriteFile("projects/" + user.Name, project["id"].ToString(), "");
                 }
             }
 
@@ -69,7 +66,7 @@ namespace Kragle
         /// </summary>
         public void DownloadProjects()
         {
-            DirectoryInfo[] users = _fs.GetDirectories("projects");
+            DirectoryInfo[] users = FileStore.GetDirectories("projects");
             int userTotal = users.Length;
             int userCurrent = 0;
 
@@ -84,7 +81,7 @@ namespace Kragle
                     userCurrent, userTotal, userCurrent / (double) userTotal));
 
                 string username = user.Name;
-                FileInfo[] projects = _fs.GetFiles("projects/" + username);
+                FileInfo[] projects = FileStore.GetFiles("projects/" + username);
 
                 // Iterate over user projects
                 foreach (FileInfo project in projects)
@@ -98,7 +95,7 @@ namespace Kragle
                     string projectDir = "code/" + projectId;
                     string fileName = DateTime.Now.ToString("yyyy-MM-dd");
 
-                    if (_fs.FileExists(projectDir, fileName))
+                    if (FileStore.FileExists(projectDir, fileName))
                     {
                         // Code already downloaded today
                         continue;
@@ -115,7 +112,7 @@ namespace Kragle
                         // Invalid JSON, no need to save it
                         continue;
                     }
-                    _fs.WriteFile(projectDir, fileName, projectCode);
+                    FileStore.WriteFile(projectDir, fileName, projectCode);
                 }
             }
 

--- a/Kragle/Kragle/ProjectScraper.cs
+++ b/Kragle/Kragle/ProjectScraper.cs
@@ -7,9 +7,10 @@ namespace Kragle
 {
     public class ProjectScraper
     {
+        private static readonly Logger Logger = Logger.GetLogger("ProjectScraper");
+
         private readonly Downloader _downloader;
         private readonly FileStore _fs;
-        private readonly Logger _logger;
 
 
         /// <summary>
@@ -21,7 +22,6 @@ namespace Kragle
         {
             _fs = fs;
             _downloader = downloader;
-            _logger = Logger.GetLogger("ProjectScraper");
         }
 
 
@@ -34,13 +34,13 @@ namespace Kragle
             int userTotal = users.Length;
             int userCurrent = 0;
 
-            _logger.Log(string.Format("Downloading project lists for {0} users.", userTotal));
+            Logger.Log(string.Format("Downloading project lists for {0} users.", userTotal));
 
             // Iterate over users
             foreach (FileInfo user in users)
             {
                 userCurrent++;
-                _logger.Log(string.Format("Downloading project list for user {0} ({1} / {2}) ({3:P2})",
+                Logger.Log(string.Format("Downloading project list for user {0} ({1} / {2}) ({3:P2})",
                     user.Name.Length > 13 ? user.Name.Substring(0, 10) + "..." : user.Name.PadRight(13, ' '),
                     userCurrent, userTotal, userCurrent / (double) userTotal));
 
@@ -61,7 +61,7 @@ namespace Kragle
                 }
             }
 
-            _logger.Log(string.Format("Successfully downloaded project lists for {0} users.\n", userCurrent));
+            Logger.Log(string.Format("Successfully downloaded project lists for {0} users.\n", userCurrent));
         }
 
         /// <summary>
@@ -73,13 +73,13 @@ namespace Kragle
             int userTotal = users.Length;
             int userCurrent = 0;
 
-            _logger.Log(string.Format("Downloading code for {0} users.", userTotal));
+            Logger.Log(string.Format("Downloading code for {0} users.", userTotal));
 
             // Iterate over users
             foreach (DirectoryInfo user in users)
             {
                 userCurrent++;
-                _logger.Log(string.Format("Downloading code for for user {0} ({1} / {2}) ({3:P2})",
+                Logger.Log(string.Format("Downloading code for for user {0} ({1} / {2}) ({3:P2})",
                     user.Name.Length > 13 ? user.Name.Substring(0, 10) + "..." : user.Name.PadRight(13, ' '),
                     userCurrent, userTotal, userCurrent / (double) userTotal));
 
@@ -119,7 +119,7 @@ namespace Kragle
                 }
             }
 
-            _logger.Log(string.Format("Successfully downloaded code for {0} users.\n", userCurrent));
+            Logger.Log(string.Format("Successfully downloaded code for {0} users.\n", userCurrent));
         }
 
 

--- a/Kragle/Kragle/ProjectScraper.cs
+++ b/Kragle/Kragle/ProjectScraper.cs
@@ -34,14 +34,15 @@ namespace Kragle
             int userTotal = users.Length;
             int userCurrent = 0;
 
-            _logger.Log("Downloading project lists for " + users.Length + " users.");
+            _logger.Log(string.Format("Downloading project lists for {0} users.", userTotal));
 
             // Iterate over users
             foreach (FileInfo user in users)
             {
                 userCurrent++;
-                _logger.Log(string.Format("{0} / {1} ({2:P2})", userCurrent, userTotal,
-                    userCurrent / (double) userTotal));
+                _logger.Log(string.Format("Downloading project list for user {0} ({1} / {2}) ({3:P2})",
+                    user.Name.Length > 13 ? user.Name.Substring(0, 10) + "..." : user.Name.PadRight(13, ' '),
+                    userCurrent, userTotal, userCurrent / (double) userTotal));
 
                 // Get list of user projects
                 JArray projects = GetUserProjects(user.Name);
@@ -59,6 +60,8 @@ namespace Kragle
                     _fs.WriteFile("projects/" + user.Name, project["id"].ToString(), "");
                 }
             }
+
+            _logger.Log(string.Format("Successfully downloaded project lists for {0} users.\n", userCurrent));
         }
 
         /// <summary>
@@ -70,11 +73,16 @@ namespace Kragle
             int userTotal = users.Length;
             int userCurrent = 0;
 
-            _logger.Log("Downloading code for " + users.Length + " users.");
+            _logger.Log(string.Format("Downloading code for {0} users.", userTotal));
 
             // Iterate over users
             foreach (DirectoryInfo user in users)
             {
+                userCurrent++;
+                _logger.Log(string.Format("Downloading code for for user {0} ({1} / {2}) ({3:P2})",
+                    user.Name.Length > 13 ? user.Name.Substring(0, 10) + "..." : user.Name.PadRight(13, ' '),
+                    userCurrent, userTotal, userCurrent / (double) userTotal));
+
                 string username = user.Name;
                 FileInfo[] projects = _fs.GetFiles("projects/" + username);
 
@@ -109,10 +117,9 @@ namespace Kragle
                     }
                     _fs.WriteFile(projectDir, fileName, projectCode);
                 }
-
-                userCurrent++;
-                _logger.Log(string.Format("{0:P2}", userCurrent / (double) userTotal));
             }
+
+            _logger.Log(string.Format("Successfully downloaded code for {0} users.\n", userCurrent));
         }
 
 

--- a/Kragle/Kragle/ProjectScraper.cs
+++ b/Kragle/Kragle/ProjectScraper.cs
@@ -9,6 +9,7 @@ namespace Kragle
     {
         private readonly Downloader _downloader;
         private readonly FileStore _fs;
+        private readonly Logger _logger;
 
 
         /// <summary>
@@ -16,10 +17,12 @@ namespace Kragle
         /// </summary>
         /// <param name="fs">the <code>FileStore</code> to use to access the filesystem</param>
         /// <param name="downloader">the <code>Downloader</code> to use for downloading data from the API</param>
-        public ProjectScraper(FileStore fs, Downloader downloader)
+        /// <param name="logger">the <code>Logger</code> to log to</param>
+        public ProjectScraper(FileStore fs, Downloader downloader, Logger logger)
         {
             _fs = fs;
             _downloader = downloader;
+            _logger = logger;
         }
 
 
@@ -32,7 +35,7 @@ namespace Kragle
             int userTotal = users.Length;
             int userCurrent = 0;
 
-            Console.WriteLine("Downloading project lists for " + users.Length + " users.");
+            _logger.LogLine("Downloading project lists for " + users.Length + " users.");
 
             // Iterate over users
             foreach (FileInfo user in users)
@@ -54,7 +57,7 @@ namespace Kragle
                 }
 
                 userCurrent++;
-                Console.WriteLine("{0:P2}", userCurrent / (double) userTotal);
+                _logger.LogLine(string.Format("{0:P2}", userCurrent / (double) userTotal));
             }
         }
 
@@ -67,7 +70,7 @@ namespace Kragle
             int userTotal = users.Length;
             int userCurrent = 0;
 
-            Console.WriteLine("Downloading code for " + users.Length + " users.");
+            _logger.LogLine("Downloading code for " + users.Length + " users.");
 
             // Iterate over users
             foreach (DirectoryInfo user in users)
@@ -108,7 +111,7 @@ namespace Kragle
                 }
 
                 userCurrent++;
-                Console.WriteLine("{0:P2}", userCurrent / (double) userTotal);
+                _logger.LogLine(string.Format("{0:P2}", userCurrent / (double) userTotal));
             }
         }
 

--- a/Kragle/Kragle/ProjectScraper.cs
+++ b/Kragle/Kragle/ProjectScraper.cs
@@ -17,12 +17,11 @@ namespace Kragle
         /// </summary>
         /// <param name="fs">the <code>FileStore</code> to use to access the filesystem</param>
         /// <param name="downloader">the <code>Downloader</code> to use for downloading data from the API</param>
-        /// <param name="logger">the <code>Logger</code> to log to</param>
-        public ProjectScraper(FileStore fs, Downloader downloader, Logger logger)
+        public ProjectScraper(FileStore fs, Downloader downloader)
         {
             _fs = fs;
             _downloader = downloader;
-            _logger = logger;
+            _logger = Logger.GetLogger("ProjectScraper");
         }
 
 
@@ -35,11 +34,15 @@ namespace Kragle
             int userTotal = users.Length;
             int userCurrent = 0;
 
-            _logger.LogLine("Downloading project lists for " + users.Length + " users.");
+            _logger.Log("Downloading project lists for " + users.Length + " users.");
 
             // Iterate over users
             foreach (FileInfo user in users)
             {
+                userCurrent++;
+                _logger.Log(string.Format("{0} / {1} ({2:P2})", userCurrent, userTotal,
+                    userCurrent / (double) userTotal));
+
                 // Get list of user projects
                 JArray projects = GetUserProjects(user.Name);
                 if (projects == null)
@@ -55,9 +58,6 @@ namespace Kragle
                 {
                     _fs.WriteFile("projects/" + user.Name, project["id"].ToString(), "");
                 }
-
-                userCurrent++;
-                _logger.LogLine(string.Format("{0:P2}", userCurrent / (double) userTotal));
             }
         }
 
@@ -70,7 +70,7 @@ namespace Kragle
             int userTotal = users.Length;
             int userCurrent = 0;
 
-            _logger.LogLine("Downloading code for " + users.Length + " users.");
+            _logger.Log("Downloading code for " + users.Length + " users.");
 
             // Iterate over users
             foreach (DirectoryInfo user in users)
@@ -111,7 +111,7 @@ namespace Kragle
                 }
 
                 userCurrent++;
-                _logger.LogLine(string.Format("{0:P2}", userCurrent / (double) userTotal));
+                _logger.Log(string.Format("{0:P2}", userCurrent / (double) userTotal));
             }
         }
 

--- a/Kragle/Kragle/UserScraper.cs
+++ b/Kragle/Kragle/UserScraper.cs
@@ -13,9 +13,10 @@ namespace Kragle
         private const string SubDirectory = "users";
         private const int PageSize = 20;
 
+        private static readonly Logger Logger = Logger.GetLogger("UserScraper");
+
         private readonly Downloader _downloader;
         private readonly FileStore _fs;
-        private readonly Logger _logger;
         private readonly int _targetUserCount;
 
 
@@ -28,7 +29,6 @@ namespace Kragle
         public UserScraper(FileStore fs, Downloader downloader, int targetUserCount)
         {
             _fs = fs;
-            _logger = Logger.GetLogger("UserScraper");
             _downloader = downloader;
             _targetUserCount = targetUserCount;
         }
@@ -42,12 +42,12 @@ namespace Kragle
             int pageNumber = 0;
             int userCount = _fs.GetFiles(SubDirectory).Length;
 
-            _logger.Log("Scraping list of recent projects.");
+            Logger.Log("Scraping list of recent projects.");
 
             // Keep downloading projects until the target has been reached
             while (userCount < _targetUserCount)
             {
-                _logger.Log(string.Format("Downloading page {0}. ({1} / {2} users registered)",
+                Logger.Log(string.Format("Downloading page {0}. ({1} / {2} users registered)",
                     pageNumber, userCount, _targetUserCount));
 
                 // Loop over projects
@@ -74,7 +74,7 @@ namespace Kragle
                 pageNumber++;
             }
 
-            _logger.Log(string.Format("Successfully registered {0} users.\n", userCount));
+            Logger.Log(string.Format("Successfully registered {0} users.\n", userCount));
         }
 
         /// <summary>
@@ -87,12 +87,12 @@ namespace Kragle
             int userTotal = users.Length;
             int userCurrent = 0;
 
-            _logger.Log(string.Format("Downloading meta-data for {0} users.", userTotal));
+            Logger.Log(string.Format("Downloading meta-data for {0} users.", userTotal));
 
             foreach (FileInfo user in users)
             {
                 userCurrent++;
-                _logger.Log(string.Format("Downloading meta-data for user {0} ({1} / {2}) ({3:P2})",
+                Logger.Log(string.Format("Downloading meta-data for user {0} ({1} / {2}) ({3:P2})",
                     user.Name.Length > 10 ? user.Name.Substring(0, 10) + "..." : user.Name.PadRight(13, ' '),
                     userCurrent, userTotal, userCurrent / (double) userTotal));
 
@@ -106,7 +106,7 @@ namespace Kragle
                 _fs.WriteFile(SubDirectory, user.Name, metaData);
             }
 
-            _logger.Log(string.Format("Successfully downloaded meta-data for {0} users.\n", userCurrent));
+            Logger.Log(string.Format("Successfully downloaded meta-data for {0} users.\n", userCurrent));
         }
 
 

--- a/Kragle/Kragle/UserScraper.cs
+++ b/Kragle/Kragle/UserScraper.cs
@@ -24,13 +24,12 @@ namespace Kragle
         /// </summary>
         /// <param name="fs">the <code>FileStore</code> to use to access the filesystem</param>
         /// <param name="downloader">the <code>Downloader</code> to download user data with</param>
-        /// <param name="logger">the <code>Logger</code> to log to</param>
         /// <param name="targetUserCount">the target number of scraped users</param>
-        public UserScraper(FileStore fs, Downloader downloader, Logger logger, int targetUserCount)
+        public UserScraper(FileStore fs, Downloader downloader, int targetUserCount)
         {
             _fs = fs;
+            _logger = Logger.GetLogger("UserScraper");
             _downloader = downloader;
-            _logger = logger;
             _targetUserCount = targetUserCount;
         }
 
@@ -43,13 +42,13 @@ namespace Kragle
             int pageNumber = 0;
             int userCount = _fs.GetFiles(SubDirectory).Length;
 
-            _logger.LogLine("Starting user scraping...\n" +
-                              userCount + " users already registered.\n\n");
+            _logger.Log("Scraping list of recent projects.");
 
             // Keep downloading projects until the target has been reached
             while (userCount < _targetUserCount)
             {
-                _logger.LogLine("Downloading page " + pageNumber);
+                _logger.Log(string.Format("Downloading page {0}. ({1} / {2} users registered)", pageNumber, userCount,
+                    _targetUserCount));
                 JArray projects = GetRecentProjects(pageNumber, PageSize);
 
                 // Loop over projects
@@ -72,7 +71,6 @@ namespace Kragle
                     }
                 }
 
-                _logger.LogLine(userCount + " / " + _targetUserCount + " users\n");
                 pageNumber++;
             }
         }
@@ -84,13 +82,19 @@ namespace Kragle
         public void DownloadMetaData()
         {
             FileInfo[] users = _fs.GetFiles(SubDirectory);
+            int userCurrent = 0;
 
-            _logger.LogLine("Downloading meta-data for " + users.Length + " users.\n");
+            _logger.Log("Downloading user meta-data.");
 
             foreach (FileInfo user in users)
             {
+                userCurrent++;
+                _logger.Log(string.Format("{0} / {1} ({2:P2})", userCurrent, users.Length,
+                    userCurrent / (double) users.Length));
+
                 if (user.Length > 0)
                 {
+                    // Meta-data already downloaded
                     continue;
                 }
 

--- a/Kragle/Kragle/UserScraper.cs
+++ b/Kragle/Kragle/UserScraper.cs
@@ -12,9 +12,10 @@ namespace Kragle
     {
         private const string SubDirectory = "users";
         private const int PageSize = 20;
-        private readonly Downloader _downloader;
 
+        private readonly Downloader _downloader;
         private readonly FileStore _fs;
+        private readonly Logger _logger;
         private readonly int _targetUserCount;
 
 
@@ -23,11 +24,13 @@ namespace Kragle
         /// </summary>
         /// <param name="fs">the <code>FileStore</code> to use to access the filesystem</param>
         /// <param name="downloader">the <code>Downloader</code> to download user data with</param>
+        /// <param name="logger">the <code>Logger</code> to log to</param>
         /// <param name="targetUserCount">the target number of scraped users</param>
-        public UserScraper(FileStore fs, Downloader downloader, int targetUserCount)
+        public UserScraper(FileStore fs, Downloader downloader, Logger logger, int targetUserCount)
         {
             _fs = fs;
             _downloader = downloader;
+            _logger = logger;
             _targetUserCount = targetUserCount;
         }
 
@@ -40,13 +43,13 @@ namespace Kragle
             int pageNumber = 0;
             int userCount = _fs.GetFiles(SubDirectory).Length;
 
-            Console.WriteLine("Starting user scraping...\n" +
+            _logger.LogLine("Starting user scraping...\n" +
                               userCount + " users already registered.\n\n");
 
             // Keep downloading projects until the target has been reached
             while (userCount < _targetUserCount)
             {
-                Console.WriteLine("Downloading page " + pageNumber);
+                _logger.LogLine("Downloading page " + pageNumber);
                 JArray projects = GetRecentProjects(pageNumber, PageSize);
 
                 // Loop over projects
@@ -69,7 +72,7 @@ namespace Kragle
                     }
                 }
 
-                Console.WriteLine(userCount + " / " + _targetUserCount + " users\n");
+                _logger.LogLine(userCount + " / " + _targetUserCount + " users\n");
                 pageNumber++;
             }
         }
@@ -82,7 +85,7 @@ namespace Kragle
         {
             FileInfo[] users = _fs.GetFiles(SubDirectory);
 
-            Console.WriteLine("Downloading meta-data for " + users.Length + " users.\n");
+            _logger.LogLine("Downloading meta-data for " + users.Length + " users.\n");
 
             foreach (FileInfo user in users)
             {

--- a/Kragle/Kragle/UserScraper.cs
+++ b/Kragle/Kragle/UserScraper.cs
@@ -16,19 +16,16 @@ namespace Kragle
         private static readonly Logger Logger = Logger.GetLogger("UserScraper");
 
         private readonly Downloader _downloader;
-        private readonly FileStore _fs;
         private readonly int _targetUserCount;
 
 
         /// <summary>
         ///     Constructs a new <code>UserScraper</code>.
         /// </summary>
-        /// <param name="fs">the <code>FileStore</code> to use to access the filesystem</param>
         /// <param name="downloader">the <code>Downloader</code> to download user data with</param>
         /// <param name="targetUserCount">the target number of scraped users</param>
-        public UserScraper(FileStore fs, Downloader downloader, int targetUserCount)
+        public UserScraper(Downloader downloader, int targetUserCount)
         {
-            _fs = fs;
             _downloader = downloader;
             _targetUserCount = targetUserCount;
         }
@@ -40,7 +37,7 @@ namespace Kragle
         public void ScrapeUsers()
         {
             int pageNumber = 0;
-            int userCount = _fs.GetFiles(SubDirectory).Length;
+            int userCount = FileStore.GetFiles(SubDirectory).Length;
 
             Logger.Log("Scraping list of recent projects.");
 
@@ -57,13 +54,13 @@ namespace Kragle
                     string fileName = project["author"]["username"].ToString();
 
                     // Skip project if user is already known
-                    if (_fs.FileExists(SubDirectory, fileName))
+                    if (FileStore.FileExists(SubDirectory, fileName))
                     {
                         continue;
                     }
 
                     // Add user
-                    _fs.WriteFile(SubDirectory, fileName, "");
+                    FileStore.WriteFile(SubDirectory, fileName, "");
                     userCount++;
                     if (userCount >= _targetUserCount)
                     {
@@ -83,7 +80,7 @@ namespace Kragle
         /// </summary>
         public void DownloadMetaData()
         {
-            FileInfo[] users = _fs.GetFiles(SubDirectory);
+            FileInfo[] users = FileStore.GetFiles(SubDirectory);
             int userTotal = users.Length;
             int userCurrent = 0;
 
@@ -103,7 +100,7 @@ namespace Kragle
                 }
 
                 string metaData = GetMetaData(user.Name);
-                _fs.WriteFile(SubDirectory, user.Name, metaData);
+                FileStore.WriteFile(SubDirectory, user.Name, metaData);
             }
 
             Logger.Log(string.Format("Successfully downloaded meta-data for {0} users.\n", userCurrent));

--- a/Kragle/Kragle/UserScraper.cs
+++ b/Kragle/Kragle/UserScraper.cs
@@ -47,11 +47,11 @@ namespace Kragle
             // Keep downloading projects until the target has been reached
             while (userCount < _targetUserCount)
             {
-                _logger.Log(string.Format("Downloading page {0}. ({1} / {2} users registered)", pageNumber, userCount,
-                    _targetUserCount));
-                JArray projects = GetRecentProjects(pageNumber, PageSize);
+                _logger.Log(string.Format("Downloading page {0}. ({1} / {2} users registered)",
+                    pageNumber, userCount, _targetUserCount));
 
                 // Loop over projects
+                JArray projects = GetRecentProjects(pageNumber, PageSize);
                 foreach (JToken project in projects)
                 {
                     string fileName = project["author"]["username"].ToString();
@@ -73,6 +73,8 @@ namespace Kragle
 
                 pageNumber++;
             }
+
+            _logger.Log(string.Format("Successfully registered {0} users.\n", userCount));
         }
 
         /// <summary>
@@ -82,15 +84,17 @@ namespace Kragle
         public void DownloadMetaData()
         {
             FileInfo[] users = _fs.GetFiles(SubDirectory);
+            int userTotal = users.Length;
             int userCurrent = 0;
 
-            _logger.Log("Downloading user meta-data.");
+            _logger.Log(string.Format("Downloading meta-data for {0} users.", userTotal));
 
             foreach (FileInfo user in users)
             {
                 userCurrent++;
-                _logger.Log(string.Format("{0} / {1} ({2:P2})", userCurrent, users.Length,
-                    userCurrent / (double) users.Length));
+                _logger.Log(string.Format("Downloading meta-data for user {0} ({1} / {2}) ({3:P2})",
+                    user.Name.Length > 10 ? user.Name.Substring(0, 10) + "..." : user.Name.PadRight(13, ' '),
+                    userCurrent, userTotal, userCurrent / (double) userTotal));
 
                 if (user.Length > 0)
                 {
@@ -101,6 +105,8 @@ namespace Kragle
                 string metaData = GetMetaData(user.Name);
                 _fs.WriteFile(SubDirectory, user.Name, metaData);
             }
+
+            _logger.Log(string.Format("Successfully downloaded meta-data for {0} users.\n", userCurrent));
         }
 
 

--- a/Kragle/KragleTests/DownloaderTests.cs
+++ b/Kragle/KragleTests/DownloaderTests.cs
@@ -96,7 +96,7 @@ namespace KragleTests
         public void AppendRandomParameterNameWithQueryComponentTest()
         {
             const string url = "https://another-website.net/?";
-            
+
             Assert.IsTrue(AppendRandomParameter(url).StartsWith(url + "random="));
         }
     }

--- a/Kragle/KragleTests/DownloaderTests.cs
+++ b/Kragle/KragleTests/DownloaderTests.cs
@@ -96,8 +96,7 @@ namespace KragleTests
         public void AppendRandomParameterNameWithQueryComponentTest()
         {
             const string url = "https://another-website.net/?";
-
-            Console.WriteLine(AppendRandomParameter(url));
+            
             Assert.IsTrue(AppendRandomParameter(url).StartsWith(url + "random="));
         }
     }

--- a/Kragle/KragleTests/KragleTests.csproj
+++ b/Kragle/KragleTests/KragleTests.csproj
@@ -55,6 +55,7 @@
   <ItemGroup>
     <Compile Include="CsvWriterTests.cs" />
     <Compile Include="FileStoreTests.cs" />
+    <Compile Include="LoggerTests.cs" />
     <Compile Include="ProjectScraperTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UserScraperTests.cs" />

--- a/Kragle/KragleTests/LoggerTests.cs
+++ b/Kragle/KragleTests/LoggerTests.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using Kragle;
+﻿using Kragle;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 
@@ -19,7 +18,7 @@ namespace KragleTests
         public void EqualsTrueTest()
         {
             Logger logger1 = Logger.GetLogger("logger1");
-            Logger logger2= Logger.GetLogger("logger1");
+            Logger logger2 = Logger.GetLogger("logger1");
             Assert.AreEqual(logger1, logger2);
         }
 

--- a/Kragle/KragleTests/LoggerTests.cs
+++ b/Kragle/KragleTests/LoggerTests.cs
@@ -1,0 +1,288 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using Kragle;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+
+namespace KragleTests
+{
+    [TestClass]
+    public class LoggerTests
+    {
+        private string _filename;
+
+
+        [TestInitialize]
+        public void SetUp()
+        {
+            _filename = Path.GetRandomFileName();
+            File.WriteAllText(_filename, "");
+        }
+
+        [TestCleanup]
+        public void TearDown()
+        {
+            File.Delete(_filename);
+        }
+
+
+        // Constructor
+        [TestMethod]
+        [SuppressMessage("ReSharper", "UnusedVariable")]
+        public void ConstructorEmptyFileTest()
+        {
+            // Test that calling constructor creates empty file
+            File.Delete(_filename);
+
+            using (Logger logger = new Logger(_filename))
+            {
+            }
+
+            Assert.AreEqual("", File.ReadAllText(_filename));
+        }
+
+        [TestMethod]
+        public void ConstructorConsoleDisabledTest()
+        {
+            using (StringWriter writer = new StringWriter())
+            {
+                Console.SetOut(writer);
+
+                using (Logger logger = new Logger(_filename) {Console = false})
+                {
+                    logger.Log("vjeGzEZvNs");
+                }
+
+                Assert.AreEqual("", writer.ToString());
+            }
+        }
+
+        [TestMethod]
+        public void ConstructorConsoleEnabledTest()
+        {
+            using (StringWriter writer = new StringWriter())
+            {
+                Console.SetOut(writer);
+
+                using (Logger logger = new Logger(_filename))
+                {
+                    logger.Log("bvGS3rh7Wz");
+                }
+
+                Assert.AreEqual("bvGS3rh7Wz", writer.ToString());
+            }
+        }
+
+
+        // Set/Get Console
+        [TestMethod]
+        public void SetGetConsoleTest()
+        {
+            using (Logger logger = new Logger())
+            {
+                logger.Console = true;
+                Assert.AreEqual(true, logger.Console);
+
+                logger.Console = false;
+                Assert.AreEqual(false, logger.Console);
+            }
+        }
+
+        [TestMethod]
+        public void SetConsoleFalseTest()
+        {
+            using (StringWriter writer = new StringWriter())
+            {
+                Console.SetOut(writer);
+
+                using (Logger logger = new Logger(_filename))
+                {
+                    logger.Console = true;
+                    logger.Log("rD1Va0QDrD");
+
+                    logger.Console = false;
+                    logger.Log("l1QMidiEh1");
+                }
+
+                Assert.AreEqual("rD1Va0QDrD", writer.ToString());
+            }
+        }
+
+        [TestMethod]
+        public void SetConsoleTrueTest()
+        {
+            using (StringWriter writer = new StringWriter())
+            {
+                Console.SetOut(writer);
+
+                using (Logger logger = new Logger(_filename))
+                {
+                    logger.Console = false;
+                    logger.Log("BZuzNRpslq");
+
+                    logger.Console = true;
+                    logger.Log("3QJPTPSOLn");
+                }
+
+                Assert.AreEqual("3QJPTPSOLn", writer.ToString());
+            }
+        }
+
+
+        // Set/Get AutoFlush
+        [TestMethod]
+        public void SetGetAutoFlushTest()
+        {
+            using (Logger logger = new Logger())
+            {
+                logger.AutoFlush = true;
+                Assert.AreEqual(true, logger.AutoFlush);
+
+                logger.AutoFlush = false;
+                Assert.AreEqual(false, logger.AutoFlush);
+            }
+        }
+
+        [TestMethod]
+        public void AutoFlushFileTrueTest()
+        {
+            using (FileStream fileIn = new FileStream(_filename, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            using (StreamReader reader = new StreamReader(fileIn))
+            using (Logger logger = new Logger(_filename) {AutoFlush = true})
+            {
+                logger.Log("vH2X3NOV8K");
+                Assert.AreEqual("vH2X3NOV8K", reader.ReadToEnd());
+            }
+        }
+
+        [TestMethod]
+        public void AutoFlushFileFalseTest()
+        {
+            using (FileStream fileIn = new FileStream(_filename, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            using (StreamReader reader = new StreamReader(fileIn))
+            using (Logger logger = new Logger(_filename) {AutoFlush = false})
+            {
+                logger.Log("67RkBj2AQE");
+                Assert.AreEqual("", reader.ReadToEnd());
+
+                logger.AutoFlush = true;
+                Assert.AreEqual("67RkBj2AQE", reader.ReadToEnd());
+            }
+        }
+
+
+        // Log
+        [TestMethod]
+        public void LogTest()
+        {
+            using (Logger logger = new Logger(_filename))
+            {
+                logger.Log("4HSrOMkg4X");
+            }
+
+            Assert.AreEqual("4HSrOMkg4X", File.ReadAllText(_filename));
+        }
+
+        [TestMethod]
+        public void LogMultipleTest()
+        {
+            using (Logger logger = new Logger(_filename))
+            {
+                logger.Log("6cLJHbijSO");
+                logger.Log("4HSrOMkg4X");
+            }
+
+            Assert.AreEqual("6cLJHbijSO4HSrOMkg4X", File.ReadAllText(_filename));
+        }
+
+        [TestMethod]
+        public void LogChainTest()
+        {
+            using (Logger logger = new Logger(_filename))
+            {
+                logger.Log("NhD7A7VpJF").Log("bVhfBW15Ku");
+            }
+
+            Assert.AreEqual("NhD7A7VpJFbVhfBW15Ku", File.ReadAllText(_filename));
+        }
+
+
+        // LogLine
+        [TestMethod]
+        public void LogLineTest()
+        {
+            using (Logger logger = new Logger(_filename))
+            {
+                logger.LogLine("9453YjrEvB");
+            }
+
+            Assert.AreEqual("9453YjrEvB" + Environment.NewLine, File.ReadAllText(_filename));
+        }
+
+        [TestMethod]
+        public void LogLineMultipleTest()
+        {
+            using (Logger logger = new Logger(_filename))
+            {
+                logger.LogLine("UaWNYl8Bnl");
+                logger.LogLine("eBHy0RksHS");
+            }
+
+            Assert.AreEqual(
+                "UaWNYl8Bnl" + Environment.NewLine + "eBHy0RksHS" + Environment.NewLine,
+                File.ReadAllText(_filename)
+            );
+        }
+
+        [TestMethod]
+        public void LogLineChainTest()
+        {
+            using (Logger logger = new Logger(_filename))
+            {
+                logger.LogLine("Zser78psU5").LogLine("Xlv0ZkP8d1");
+            }
+
+            Assert.AreEqual(
+                "Zser78psU5" + Environment.NewLine + "Xlv0ZkP8d1" + Environment.NewLine,
+                File.ReadAllText(_filename)
+            );
+        }
+
+
+        // Flush
+        [TestMethod]
+        public void FlushConsoleTest()
+        {
+            using (FileStream fileIn = new FileStream(_filename, FileMode.Append, FileAccess.Write, FileShare.Read))
+            using (FileStream fileOut = new FileStream(_filename, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            using (StreamWriter writer = new StreamWriter(fileIn) {AutoFlush = false}) // "Console" does not flush
+            using (StreamReader reader = new StreamReader(fileOut))
+            using (Logger logger = new Logger {AutoFlush = false}) // Logger does not flush either
+            {
+                Console.SetOut(writer);
+
+                logger.Log("eb7nplzYBG");
+                Assert.AreEqual("", reader.ReadToEnd());
+
+                logger.Log("EICUpWeTDt").Flush();
+                Assert.AreEqual("eb7nplzYBGEICUpWeTDt", reader.ReadToEnd());
+            }
+        }
+
+        [TestMethod]
+        public void FlushFileTest()
+        {
+            using (FileStream fileIn = new FileStream(_filename, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            using (StreamReader reader = new StreamReader(fileIn))
+            using (Logger logger = new Logger(_filename) {AutoFlush = false})
+            {
+                logger.Log("vH2X3NOV8K");
+                Assert.AreEqual("", reader.ReadToEnd());
+
+                logger.Log("N1BpV8sTHJ").Flush();
+                Assert.AreEqual("vH2X3NOV8KN1BpV8sTHJ", reader.ReadToEnd());
+            }
+        }
+    }
+}

--- a/Kragle/KragleTests/LoggerTests.cs
+++ b/Kragle/KragleTests/LoggerTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
-using System.IO;
+﻿using System.IO;
 using Kragle;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -10,279 +8,27 @@ namespace KragleTests
     [TestClass]
     public class LoggerTests
     {
-        private string _filename;
-
-
-        [TestInitialize]
-        public void SetUp()
-        {
-            _filename = Path.GetRandomFileName();
-            File.WriteAllText(_filename, "");
-        }
-
-        [TestCleanup]
-        public void TearDown()
-        {
-            File.Delete(_filename);
-        }
-
-
-        // Constructor
         [TestMethod]
-        [SuppressMessage("ReSharper", "UnusedVariable")]
-        public void ConstructorEmptyFileTest()
+        public void GetNameTest()
         {
-            // Test that calling constructor creates empty file
-            File.Delete(_filename);
-
-            using (Logger logger = new Logger(_filename))
-            {
-            }
-
-            Assert.AreEqual("", File.ReadAllText(_filename));
+            Logger logger = Logger.GetLogger("logger name");
+            Assert.AreEqual("logger name", logger.Name);
         }
 
         [TestMethod]
-        public void ConstructorConsoleDisabledTest()
+        public void EqualsTrueTest()
         {
-            using (StringWriter writer = new StringWriter())
-            {
-                Console.SetOut(writer);
-
-                using (Logger logger = new Logger(_filename) {Console = false})
-                {
-                    logger.Log("vjeGzEZvNs");
-                }
-
-                Assert.AreEqual("", writer.ToString());
-            }
+            Logger logger1 = Logger.GetLogger("logger1");
+            Logger logger2= Logger.GetLogger("logger1");
+            Assert.AreEqual(logger1, logger2);
         }
 
         [TestMethod]
-        public void ConstructorConsoleEnabledTest()
+        public void EqualsFalseTest()
         {
-            using (StringWriter writer = new StringWriter())
-            {
-                Console.SetOut(writer);
-
-                using (Logger logger = new Logger(_filename))
-                {
-                    logger.Log("bvGS3rh7Wz");
-                }
-
-                Assert.AreEqual("bvGS3rh7Wz", writer.ToString());
-            }
-        }
-
-
-        // Set/Get Console
-        [TestMethod]
-        public void SetGetConsoleTest()
-        {
-            using (Logger logger = new Logger())
-            {
-                logger.Console = true;
-                Assert.AreEqual(true, logger.Console);
-
-                logger.Console = false;
-                Assert.AreEqual(false, logger.Console);
-            }
-        }
-
-        [TestMethod]
-        public void SetConsoleFalseTest()
-        {
-            using (StringWriter writer = new StringWriter())
-            {
-                Console.SetOut(writer);
-
-                using (Logger logger = new Logger(_filename))
-                {
-                    logger.Console = true;
-                    logger.Log("rD1Va0QDrD");
-
-                    logger.Console = false;
-                    logger.Log("l1QMidiEh1");
-                }
-
-                Assert.AreEqual("rD1Va0QDrD", writer.ToString());
-            }
-        }
-
-        [TestMethod]
-        public void SetConsoleTrueTest()
-        {
-            using (StringWriter writer = new StringWriter())
-            {
-                Console.SetOut(writer);
-
-                using (Logger logger = new Logger(_filename))
-                {
-                    logger.Console = false;
-                    logger.Log("BZuzNRpslq");
-
-                    logger.Console = true;
-                    logger.Log("3QJPTPSOLn");
-                }
-
-                Assert.AreEqual("3QJPTPSOLn", writer.ToString());
-            }
-        }
-
-
-        // Set/Get AutoFlush
-        [TestMethod]
-        public void SetGetAutoFlushTest()
-        {
-            using (Logger logger = new Logger())
-            {
-                logger.AutoFlush = true;
-                Assert.AreEqual(true, logger.AutoFlush);
-
-                logger.AutoFlush = false;
-                Assert.AreEqual(false, logger.AutoFlush);
-            }
-        }
-
-        [TestMethod]
-        public void AutoFlushFileTrueTest()
-        {
-            using (FileStream fileIn = new FileStream(_filename, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
-            using (StreamReader reader = new StreamReader(fileIn))
-            using (Logger logger = new Logger(_filename) {AutoFlush = true})
-            {
-                logger.Log("vH2X3NOV8K");
-                Assert.AreEqual("vH2X3NOV8K", reader.ReadToEnd());
-            }
-        }
-
-        [TestMethod]
-        public void AutoFlushFileFalseTest()
-        {
-            using (FileStream fileIn = new FileStream(_filename, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
-            using (StreamReader reader = new StreamReader(fileIn))
-            using (Logger logger = new Logger(_filename) {AutoFlush = false})
-            {
-                logger.Log("67RkBj2AQE");
-                Assert.AreEqual("", reader.ReadToEnd());
-
-                logger.AutoFlush = true;
-                Assert.AreEqual("67RkBj2AQE", reader.ReadToEnd());
-            }
-        }
-
-
-        // Log
-        [TestMethod]
-        public void LogTest()
-        {
-            using (Logger logger = new Logger(_filename))
-            {
-                logger.Log("4HSrOMkg4X");
-            }
-
-            Assert.AreEqual("4HSrOMkg4X", File.ReadAllText(_filename));
-        }
-
-        [TestMethod]
-        public void LogMultipleTest()
-        {
-            using (Logger logger = new Logger(_filename))
-            {
-                logger.Log("6cLJHbijSO");
-                logger.Log("4HSrOMkg4X");
-            }
-
-            Assert.AreEqual("6cLJHbijSO4HSrOMkg4X", File.ReadAllText(_filename));
-        }
-
-        [TestMethod]
-        public void LogChainTest()
-        {
-            using (Logger logger = new Logger(_filename))
-            {
-                logger.Log("NhD7A7VpJF").Log("bVhfBW15Ku");
-            }
-
-            Assert.AreEqual("NhD7A7VpJFbVhfBW15Ku", File.ReadAllText(_filename));
-        }
-
-
-        // LogLine
-        [TestMethod]
-        public void LogLineTest()
-        {
-            using (Logger logger = new Logger(_filename))
-            {
-                logger.LogLine("9453YjrEvB");
-            }
-
-            Assert.AreEqual("9453YjrEvB" + Environment.NewLine, File.ReadAllText(_filename));
-        }
-
-        [TestMethod]
-        public void LogLineMultipleTest()
-        {
-            using (Logger logger = new Logger(_filename))
-            {
-                logger.LogLine("UaWNYl8Bnl");
-                logger.LogLine("eBHy0RksHS");
-            }
-
-            Assert.AreEqual(
-                "UaWNYl8Bnl" + Environment.NewLine + "eBHy0RksHS" + Environment.NewLine,
-                File.ReadAllText(_filename)
-            );
-        }
-
-        [TestMethod]
-        public void LogLineChainTest()
-        {
-            using (Logger logger = new Logger(_filename))
-            {
-                logger.LogLine("Zser78psU5").LogLine("Xlv0ZkP8d1");
-            }
-
-            Assert.AreEqual(
-                "Zser78psU5" + Environment.NewLine + "Xlv0ZkP8d1" + Environment.NewLine,
-                File.ReadAllText(_filename)
-            );
-        }
-
-
-        // Flush
-        [TestMethod]
-        public void FlushConsoleTest()
-        {
-            using (FileStream fileIn = new FileStream(_filename, FileMode.Append, FileAccess.Write, FileShare.Read))
-            using (FileStream fileOut = new FileStream(_filename, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
-            using (StreamWriter writer = new StreamWriter(fileIn) {AutoFlush = false}) // "Console" does not flush
-            using (StreamReader reader = new StreamReader(fileOut))
-            using (Logger logger = new Logger {AutoFlush = false}) // Logger does not flush either
-            {
-                Console.SetOut(writer);
-
-                logger.Log("eb7nplzYBG");
-                Assert.AreEqual("", reader.ReadToEnd());
-
-                logger.Log("EICUpWeTDt").Flush();
-                Assert.AreEqual("eb7nplzYBGEICUpWeTDt", reader.ReadToEnd());
-            }
-        }
-
-        [TestMethod]
-        public void FlushFileTest()
-        {
-            using (FileStream fileIn = new FileStream(_filename, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
-            using (StreamReader reader = new StreamReader(fileIn))
-            using (Logger logger = new Logger(_filename) {AutoFlush = false})
-            {
-                logger.Log("vH2X3NOV8K");
-                Assert.AreEqual("", reader.ReadToEnd());
-
-                logger.Log("N1BpV8sTHJ").Flush();
-                Assert.AreEqual("vH2X3NOV8KN1BpV8sTHJ", reader.ReadToEnd());
-            }
+            Logger logger1 = Logger.GetLogger("logger1");
+            Logger logger2 = Logger.GetLogger("logger2");
+            Assert.AreNotEqual(logger1, logger2);
         }
     }
 }

--- a/Kragle/KragleTests/ProjectScraperTests.cs
+++ b/Kragle/KragleTests/ProjectScraperTests.cs
@@ -7,7 +7,7 @@ namespace KragleTests
     [TestClass]
     public class ProjectScraperTests : ProjectScraper
     {
-        public ProjectScraperTests() : base(new FileStore(), new Downloader(false))
+        public ProjectScraperTests() : base(new Downloader(false))
         {
         }
 

--- a/Kragle/KragleTests/ProjectScraperTests.cs
+++ b/Kragle/KragleTests/ProjectScraperTests.cs
@@ -7,7 +7,7 @@ namespace KragleTests
     [TestClass]
     public class ProjectScraperTests : ProjectScraper
     {
-        public ProjectScraperTests() : base(new FileStore(), new Downloader(false))
+        public ProjectScraperTests() : base(new FileStore(), new Downloader(false), new Logger())
         {
         }
 

--- a/Kragle/KragleTests/ProjectScraperTests.cs
+++ b/Kragle/KragleTests/ProjectScraperTests.cs
@@ -7,7 +7,7 @@ namespace KragleTests
     [TestClass]
     public class ProjectScraperTests : ProjectScraper
     {
-        public ProjectScraperTests() : base(new FileStore(), new Downloader(false), new Logger())
+        public ProjectScraperTests() : base(new FileStore(), new Downloader(false))
         {
         }
 

--- a/Kragle/KragleTests/UserScraperTests.cs
+++ b/Kragle/KragleTests/UserScraperTests.cs
@@ -10,7 +10,7 @@ namespace KragleTests
     [TestClass]
     public class UserScraperTests : UserScraper
     {
-        public UserScraperTests() : base(new FileStore(), new Downloader(true), int.MaxValue)
+        public UserScraperTests() : base(new Downloader(true), int.MaxValue)
         {
         }
 

--- a/Kragle/KragleTests/UserScraperTests.cs
+++ b/Kragle/KragleTests/UserScraperTests.cs
@@ -10,7 +10,7 @@ namespace KragleTests
     [TestClass]
     public class UserScraperTests : UserScraper
     {
-        public UserScraperTests() : base(new FileStore(), new Downloader(true), new Logger(), int.MaxValue)
+        public UserScraperTests() : base(new FileStore(), new Downloader(true), int.MaxValue)
         {
         }
 

--- a/Kragle/KragleTests/UserScraperTests.cs
+++ b/Kragle/KragleTests/UserScraperTests.cs
@@ -10,7 +10,7 @@ namespace KragleTests
     [TestClass]
     public class UserScraperTests : UserScraper
     {
-        public UserScraperTests() : base(new FileStore(), new Downloader(true), int.MaxValue)
+        public UserScraperTests() : base(new FileStore(), new Downloader(true), new Logger(), int.MaxValue)
         {
         }
 

--- a/Kragle/KragleTests/packages.config
+++ b/Kragle/KragleTests/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+
 <packages>
   <package id="Newtonsoft.Json" version="10.0.1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Introduces the `Logger` class. Instead of only writing messages to the console, all messages are now permanently saved to a text file. The `Logger` class is a static class. Because the `FileStore` is used by the `Logger` to save log files, I have also made the `FileStore` a static class.

All `Logger` instances have a name, typically to reflect the class from which they are used, and use the same stream to write their messages. To prevent excessive instances from being created, all `Logger` instances are created by a static `GetLogger` method that maps `Logger` names to instances.

I have also added many new messages to be written during execution. Because all messages are timestamped, this allows us to see afterwards how long certain parts (e.g. downloading, parsing) of the program take; and it allows us to understand why the program may have crashed.
