### PR TITLE
Exception logging

### DIFF
--- a/Kragle/Kragle/CodeParser.cs
+++ b/Kragle/Kragle/CodeParser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Kragle.Properties;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 
@@ -24,12 +25,21 @@ namespace Kragle
         {
             using (CsvWriter writer = new CsvWriter(FileStore.GetAbsolutePath(Resources.UsersCsv)))
             {
-                FileInfo[] users = FileStore.GetFiles(Resources.UserDirectory);
-                Logger.Log("Writing " + users.Length + " users to CSV.");
+                FileInfo[] userFiles = FileStore.GetFiles(Resources.UserDirectory);
+                Logger.Log("Writing " + userFiles.Length + " users to CSV.");
 
-                foreach (FileInfo userFile in users)
+                foreach (FileInfo userFile in userFiles)
                 {
-                    JObject user = JObject.Parse(File.ReadAllText(userFile.FullName));
+                    JObject user;
+                    try
+                    {
+                        user = JObject.Parse(File.ReadAllText(userFile.FullName));
+                    }
+                    catch (JsonReaderException e)
+                    {
+                        Logger.Log("The user meta data for user `" + userFile.Name + "` could not be parsed.", e);
+                        return;
+                    }
 
                     writer
                         .Write(int.Parse(user["id"].ToString()))
@@ -49,21 +59,31 @@ namespace Kragle
             using (CsvWriter projectWriter = new CsvWriter(FileStore.GetAbsolutePath(Resources.ProjectsCsv)))
             using (CsvWriter projectRemixWriter = new CsvWriter(FileStore.GetAbsolutePath(Resources.ProjectRemixCsv)))
             {
-                FileInfo[] users = FileStore.GetFiles(Resources.ProjectDirectory);
-                Logger.Log("Writing " + users.Length + " projects to CSV.");
+                FileInfo[] userFiles = FileStore.GetFiles(Resources.ProjectDirectory);
+                Logger.Log("Writing " + userFiles.Length + " projects to CSV.");
 
-                foreach (FileInfo user in users)
+                foreach (FileInfo userFile in userFiles)
                 {
-                    JArray projectInfo = JArray.Parse(File.ReadAllText(user.FullName));
-
-                    foreach (JToken jToken in projectInfo)
+                    JArray projectFiles;
+                    try
                     {
-                        if (!(jToken is JObject))
+                        projectFiles = JArray.Parse(File.ReadAllText(userFile.FullName));
+                    }
+                    catch (JsonReaderException e)
+                    {
+                        Logger.Log("The project list for user `" + userFile.Name + "` could not be parsed.", e);
+                        return;
+                    }
+
+                    foreach (JToken projectFile in projectFiles)
+                    {
+                        if (!(projectFile is JObject))
                         {
-                            continue;
+                            Logger.Log("\nA project of user `" + userFile.Name + "` could not be parsed.");
+                            return;
                         }
 
-                        JObject project = (JObject) jToken;
+                        JObject project = (JObject) projectFile;
                         int authorId = int.Parse(project["author"]["id"].ToString());
                         int projectId = int.Parse(project["id"].ToString());
                         string remixParentId = project["remix"]["parent"].ToString();
@@ -88,25 +108,37 @@ namespace Kragle
 
             using (CsvWriter projectMetaWriter = new CsvWriter(FileStore.GetAbsolutePath(Resources.ProjectMetaCsv)))
             {
-                DirectoryInfo[] users = FileStore.GetDirectories(Resources.ProjectDirectory);
-                Logger.Log("Writing meta data for " + users.Length + " projects to CSV.");
+                DirectoryInfo[] userDirs = FileStore.GetDirectories(Resources.ProjectDirectory);
+                Logger.Log("Writing meta data for " + userDirs.Length + " projects to CSV.");
 
-                foreach (DirectoryInfo user in users)
+                foreach (DirectoryInfo userDir in userDirs)
                 {
-                    foreach (FileInfo metaFile in user.GetFiles())
+                    foreach (FileInfo projectFile in userDir.GetFiles())
                     {
-                        JArray projectInfo = JArray.Parse(File.ReadAllText(metaFile.FullName));
-
-                        foreach (JToken jToken in projectInfo)
+                        JArray projects;
+                        try
                         {
-                            if (!(jToken is JObject))
+                            projects = JArray.Parse(File.ReadAllText(projectFile.FullName));
+                        }
+                        catch (JsonReaderException e)
+                        {
+                            Logger.Log("The project meta data list of user `" + userDir.Name + "` could not be parsed.",
+                                e);
+                            return;
+                        }
+
+                        foreach (JToken project in projects)
+                        {
+                            if (!(project is JObject))
                             {
-                                continue;
+                                Logger.Log("\nThe meta data of a project of user `" + userDir.Name +
+                                           "` could not be parsed.");
+                                return;
                             }
 
-                            JObject metaData = (JObject) jToken;
+                            JObject metaData = (JObject) project;
                             int projectId = int.Parse(metaData["id"].ToString());
-                            string dataDate = metaFile.Name.Substring(0, metaFile.Name.Length - 5);
+                            string dataDate = projectFile.Name.Substring(0, projectFile.Name.Length - 5);
 
                             projectMetaWriter
                                 .Write(projectId)

--- a/Kragle/Kragle/Logger.cs
+++ b/Kragle/Kragle/Logger.cs
@@ -113,5 +113,25 @@ namespace Kragle
         {
             Log(Name, text);
         }
+
+        /// <summary>
+        ///     Logs an <code>Exception</code>. The <code>Exception</code> is converted to a string and logged.
+        /// </summary>
+        /// <param name="e">an <code>Exception</code></param>
+        public void Log(Exception e)
+        {
+            Log(e.ToString());
+        }
+
+        /// <summary>
+        ///     Logs an <code>Exception</code> and a description of why the <code>Exception</code> may have occurred.
+        /// </summary>
+        /// <param name="description">a description of why the <code>Exception</code> may have occurred</param>
+        /// <param name="e">an <code>Exception</code></param>
+        public void Log(string description, Exception e)
+        {
+            Log("\n" + description);
+            Log(e);
+        }
     }
 }

--- a/Kragle/Kragle/ProjectScraper.cs
+++ b/Kragle/Kragle/ProjectScraper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using Kragle.Properties;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 
@@ -54,7 +55,8 @@ namespace Kragle
 
                 // Save list of projects
                 FileStore.WriteFile(Resources.ProjectDirectory, username + ".json", projects);
-                FileStore.WriteFile(Resources.ProjectDirectory + "/" + username, currentDate.ToString("yyyy-MM-dd") + ".json", projects);
+                FileStore.WriteFile(Resources.ProjectDirectory + "/" + username,
+                    currentDate.ToString("yyyy-MM-dd") + ".json", projects);
             }
 
             Logger.Log(string.Format("Successfully downloaded project lists for {0} users.\n", userCurrent));
@@ -82,7 +84,16 @@ namespace Kragle
                 Logger.Log(LoggerHelper.FormatProgress(
                     "Downloading code for user " + LoggerHelper.ForceLength(username, 10), userCurrent, userTotal));
 
-                JArray projects = JArray.Parse(FileStore.ReadFile(Resources.ProjectDirectory, username + ".json"));
+                JArray projects;
+                try
+                {
+                    projects = JArray.Parse(FileStore.ReadFile(Resources.ProjectDirectory, username + ".json"));
+                }
+                catch (JsonReaderException e)
+                {
+                    Logger.Log("Could not parse list of projects of user `" + username + "`", e);
+                    return;
+                }
 
                 // Iterate over user projects
                 foreach (JToken project in projects)


### PR DESCRIPTION
Allows the logging of `Exception`s and implements this for `JsonReaderException`s (which are caused by attempting to parse non-JSON strings).

* Adds two overloads for the `Log` method in the `Logger` to explicitly log an `Exception`, possibly with a description of the probably cause of the `Exception`.
* Adds `try`-`catch` clauses around all attempts to parse a JSON string and logs the exception if it occurs. The method is then aborted.

It might be an idea to log other `Exception`s that may occur, such as those generated when a file cannot be read, but I feel that that should be in another PR.
