### PR TITLE
Parse missing info

### DIFF
--- a/Kragle/Kragle/CodeParser.cs
+++ b/Kragle/Kragle/CodeParser.cs
@@ -27,9 +27,26 @@ namespace Kragle
                 FileInfo[] users = FileStore.GetFiles(Resources.UserDirectory);
                 Logger.Log("Writing " + users.Length + " users to CSV.");
 
+                if (users.Length > 0 && File.ReadAllText(users[0].FullName).Length == 0)
+                {
+                    Logger.Log("Missing meta-data for users.");
+                    Logger.Log("Parsing was aborted.");
+                    Console.ReadLine();
+                    Environment.Exit(-1);
+                }
+
                 foreach (FileInfo userFile in users)
                 {
-                    JObject user = JObject.Parse(File.ReadAllText(userFile.FullName));
+                    string contents = File.ReadAllText(userFile.FullName);
+                    if (contents.Length == 0)
+                    {
+                        Logger.Log("Missing meta-data for user " + userFile.Name);
+                        Logger.Log("Parsing was aborted.");
+                        Console.ReadLine();
+                        Environment.Exit(-1);
+                    }
+
+                    JObject user = JObject.Parse(contents);
 
                     writer
                         .Write(int.Parse(user["id"].ToString()))

--- a/Kragle/Kragle/Logger.cs
+++ b/Kragle/Kragle/Logger.cs
@@ -113,5 +113,25 @@ namespace Kragle
         {
             Log(Name, text);
         }
+
+        /// <summary>
+        ///     Logs an <code>Exception</code>. The <code>Exception</code> is converted to a string and logged.
+        /// </summary>
+        /// <param name="e">an <code>Exception</code></param>
+        public void Log(Exception e)
+        {
+            Log(e.ToString());
+        }
+
+        /// <summary>
+        ///     Logs an <code>Exception</code> and a description of why the <code>Exception</code> may have occurred.
+        /// </summary>
+        /// <param name="description">a description of why the <code>Exception</code> may have occurred</param>
+        /// <param name="e">an <code>Exception</code></param>
+        public void Log(string description, Exception e)
+        {
+            Log("\n" + description);
+            Log(e);
+        }
     }
 }

--- a/Kragle/Kragle/ProjectScraper.cs
+++ b/Kragle/Kragle/ProjectScraper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using Kragle.Properties;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 
@@ -54,7 +55,8 @@ namespace Kragle
 
                 // Save list of projects
                 FileStore.WriteFile(Resources.ProjectDirectory, username + ".json", projects);
-                FileStore.WriteFile(Resources.ProjectDirectory + "/" + username, currentDate.ToString("yyyy-MM-dd") + ".json", projects);
+                FileStore.WriteFile(Resources.ProjectDirectory + "/" + username,
+                    currentDate.ToString("yyyy-MM-dd") + ".json", projects);
             }
 
             Logger.Log(string.Format("Successfully downloaded project lists for {0} users.\n", userCurrent));
@@ -82,7 +84,16 @@ namespace Kragle
                 Logger.Log(LoggerHelper.FormatProgress(
                     "Downloading code for user " + LoggerHelper.ForceLength(username, 10), userCurrent, userTotal));
 
-                JArray projects = JArray.Parse(FileStore.ReadFile(Resources.ProjectDirectory, username + ".json"));
+                JArray projects;
+                try
+                {
+                    projects = JArray.Parse(FileStore.ReadFile(Resources.ProjectDirectory, username + ".json"));
+                }
+                catch (JsonReaderException e)
+                {
+                    Logger.Log("Could not parse list of projects of user `" + username + "`", e);
+                    return;
+                }
 
                 // Iterate over user projects
                 foreach (JToken project in projects)


### PR DESCRIPTION
The program will crash if the data is parsed while user meta data has been downloaded. This PR prevents that by explicitly checking that the read file is not empty; if it is, the current method (and with that the program) is aborted.
This PR also includes the changes proposed in #13; I would recommend merging it before reviewing this PR.
