### PR TITLE
Refactor command line options structure

### DIFF
--- a/Kragle/Kragle/ConsoleOptions/OpenSubOptions.cs
+++ b/Kragle/Kragle/ConsoleOptions/OpenSubOptions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Diagnostics;
+
+
+namespace Kragle.ConsoleOptions
+{
+    /// <summary>
+    ///     Command-line options for the 'open' verb.
+    /// </summary>
+    public class OpenSubOptions : SubOptions
+    {
+        /// <summary>
+        ///     Opens the output directory in Windows Explorer.
+        /// </summary>
+        public override void Run()
+        {
+            FileStore.Init(Path);
+            Process.Start(FileStore.GetRootPath());
+
+            Environment.Exit(0); // Suppress exit message
+        }
+    }
+}

--- a/Kragle/Kragle/ConsoleOptions/Options.cs
+++ b/Kragle/Kragle/ConsoleOptions/Options.cs
@@ -1,0 +1,40 @@
+﻿using CommandLine;
+using CommandLine.Text;
+
+
+namespace Kragle.ConsoleOptions
+{
+    /// <summary>
+    ///     Available verb commands for the command line.
+    /// </summary>
+    public class Options
+    {
+        [VerbOption("reset", HelpText = "Reset all files")]
+        public ResetSubOptions ResetSubOptions { get; set; }
+
+        [VerbOption("open", HelpText = "Opens the data folder in Windows Explorer")]
+        public OpenSubOptions OpenSubOptions { get; set; }
+
+        [VerbOption("users", HelpText = "Generate/update the list of users who most recently shared a project")]
+        public UsersSubOptions UsersSubOptions { get; set; }
+
+        [VerbOption("projects", HelpText = "Generate the list of projects of all registered users")]
+        public ProjectsSubOptions ProjectsSubOptions { get; set; }
+
+        [VerbOption("parse", HelpText = "Generate the list of projects of all registered users")]
+        public ParseSubOptions ParseSubOptions { get; set; }
+
+
+        [HelpOption]
+        public string GetUsage()
+        {
+            return HelpText.AutoBuild(this, current => HelpText.DefaultParsingErrorsHandler(this, current));
+        }
+
+        [HelpVerbOption]
+        public string GetUsage(string verb)
+        {
+            return HelpText.AutoBuild(this, verb);
+        }
+    }
+}

--- a/Kragle/Kragle/ConsoleOptions/ParseSubOptions.cs
+++ b/Kragle/Kragle/ConsoleOptions/ParseSubOptions.cs
@@ -1,0 +1,21 @@
+﻿namespace Kragle.ConsoleOptions
+{
+    /// <summary>
+    ///     Command-line options for the 'parse' verb.
+    /// </summary>
+    public class ParseSubOptions : SubOptions
+    {
+        /// <summary>
+        ///     Parses users, projects, and project code.
+        /// </summary>
+        public override void Run()
+        {
+            FileStore.Init(Path);
+
+            CodeParser parser = new CodeParser();
+            parser.WriteUsers();
+            parser.WriteProjects();
+            parser.WriteCode();
+        }
+    }
+}

--- a/Kragle/Kragle/ConsoleOptions/ProjectsSubOptions.cs
+++ b/Kragle/Kragle/ConsoleOptions/ProjectsSubOptions.cs
@@ -1,0 +1,38 @@
+﻿using CommandLine;
+
+
+namespace Kragle.ConsoleOptions
+{
+    /// <summary>
+    ///     Command-line options for the 'projects' verb.
+    /// </summary>
+    public class ProjectsSubOptions : SubOptions
+    {
+        [Option('u', "update", HelpText = "Update the list of registered projects")]
+        public bool Update { get; set; }
+
+        [Option('d', "download", HelpText = "Download project code")]
+        public bool Download { get; set; }
+
+
+        /// <summary>
+        ///     Updates and/or downloads project code.
+        /// </summary>
+        public override void Run()
+        {
+            FileStore.Init(Path);
+
+            Downloader downloader = new Downloader {UseCache = Cache};
+            ProjectScraper scraper = new ProjectScraper(downloader);
+
+            if (Update)
+            {
+                scraper.UpdateProjectList();
+            }
+            if (Download)
+            {
+                scraper.DownloadProjects();
+            }
+        }
+    }
+}

--- a/Kragle/Kragle/ConsoleOptions/ResetSubOptions.cs
+++ b/Kragle/Kragle/ConsoleOptions/ResetSubOptions.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Kragle.Properties;
+
+
+namespace Kragle.ConsoleOptions
+{
+    /// <summary>
+    ///     Command-line options for the 'reset' verb.
+    /// </summary>
+    public class ResetSubOptions : SubOptions
+    {
+        /// <summary>
+        ///     Removes all downloaded and parsed data.
+        /// </summary>
+        public override void Run()
+        {
+            FileStore.Init(Path);
+
+            Console.Write(Resources.ResetRequestConfirmation);
+            string confirm = Console.ReadLine();
+
+            if (confirm != null && confirm.ToLower() == "y")
+            {
+                FileStore.RemoveDirectory(Resources.UserDirectory);
+                FileStore.RemoveDirectory(Resources.ProjectDirectory);
+                FileStore.RemoveDirectory(Resources.CodeDirectory);
+                Console.WriteLine(Resources.ResetConfirmSuccess);
+            }
+            else
+            {
+                Console.WriteLine(Resources.ResetConfirmCancel);
+            }
+
+            Environment.Exit(0); // Suppress exit message
+        }
+    }
+}

--- a/Kragle/Kragle/ConsoleOptions/SubOptions.cs
+++ b/Kragle/Kragle/ConsoleOptions/SubOptions.cs
@@ -1,0 +1,23 @@
+﻿using CommandLine;
+
+
+namespace Kragle.ConsoleOptions
+{
+    /// <summary>
+    ///     Command-line options for all verbs interacting with the file system.
+    /// </summary>
+    public abstract class SubOptions
+    {
+        [Option('p', "path", HelpText = "The path files should be read from and written to")]
+        public string Path { get; set; }
+
+        [Option('c', "cache", HelpText = "Enable caching; speeds up the process significantly")]
+        public bool Cache { get; set; }
+
+
+        /// <summary>
+        ///     Executes the action corresponding to this sub-option.
+        /// </summary>
+        public abstract void Run();
+    }
+}

--- a/Kragle/Kragle/ConsoleOptions/UsersSubOptions.cs
+++ b/Kragle/Kragle/ConsoleOptions/UsersSubOptions.cs
@@ -1,0 +1,34 @@
+﻿using CommandLine;
+
+
+namespace Kragle.ConsoleOptions
+{
+    /// <summary>
+    ///     Command-line options for the 'users' verb.
+    /// </summary>
+    public class UsersSubOptions : SubOptions
+    {
+        [Option('n', "number", DefaultValue = int.MaxValue, HelpText = "The number of users to scrape")]
+        public int Count { get; set; }
+
+        [Option('m', "meta", HelpText = "Download user meta-data")]
+        public bool Meta { get; set; }
+
+
+        /// <summary>
+        ///     Scrapes users.
+        /// </summary>
+        public override void Run()
+        {
+            FileStore.Init(Path);
+            Downloader downloader = new Downloader {UseCache = Cache};
+            UserScraper scraper = new UserScraper(downloader, Count);
+
+            scraper.ScrapeUsers();
+            if (Meta)
+            {
+                scraper.DownloadMetaData();
+            }
+        }
+    }
+}

--- a/Kragle/Kragle/Kragle.csproj
+++ b/Kragle/Kragle/Kragle.csproj
@@ -65,6 +65,13 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CodeParser.cs" />
+    <Compile Include="ConsoleOptions\ParseSubOptions.cs" />
+    <Compile Include="ConsoleOptions\SubOptions.cs" />
+    <Compile Include="ConsoleOptions\OpenSubOptions.cs" />
+    <Compile Include="ConsoleOptions\ProjectsSubOptions.cs" />
+    <Compile Include="ConsoleOptions\UsersSubOptions.cs" />
+    <Compile Include="ConsoleOptions\Options.cs" />
+    <Compile Include="ConsoleOptions\ResetSubOptions.cs" />
     <Compile Include="CsvWriter.cs" />
     <Compile Include="FileStore.cs" />
     <Compile Include="Logger.cs" />

--- a/Kragle/Kragle/Program.cs
+++ b/Kragle/Kragle/Program.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Diagnostics;
 using CommandLine;
-using CommandLine.Text;
-using Kragle.Properties;
+using Kragle.ConsoleOptions;
 
 
 namespace Kragle
@@ -12,220 +10,34 @@ namespace Kragle
     /// </summary>
     internal class Program
     {
-        private static string _invokedVerb;
-        private static object _invokedVerbInstance;
-
-
         /// <summary>
         ///     Application entry point.
         /// </summary>
         /// <param name="args">the command-line arguments</param>
         private static void Main(string[] args)
         {
-            // Parse options
             if (args == null || args.Length == 0)
             {
                 Environment.Exit(1);
             }
 
+            
             Options options = new Options();
             if (!Parser.Default.ParseArguments(args, options, (verb, subOptions) =>
             {
-                _invokedVerb = verb;
-                _invokedVerbInstance = subOptions;
+                if (!(subOptions is SubOptions))
+                {
+                    Environment.Exit(Parser.DefaultExitCodeFail);
+                }
+
+                ((SubOptions) subOptions).Run();
             }))
             {
                 Environment.Exit(Parser.DefaultExitCodeFail);
             }
 
-            // Select action
-            switch (_invokedVerb)
-            {
-                case "reset":
-                {
-                    ResetSubOptions subOptions = (ResetSubOptions) _invokedVerbInstance;
-                    FileStore.Init(subOptions.Path);
-
-                    Console.Write(Resources.ResetRequestConfirmation);
-                    string confirm = Console.ReadLine();
-
-                    if (confirm != null && confirm.ToLower() == "y")
-                    {
-                        FileStore.RemoveDirectory(Resources.UserDirectory);
-                        FileStore.RemoveDirectory(Resources.ProjectDirectory);
-                        FileStore.RemoveDirectory(Resources.CodeDirectory);
-                        Console.WriteLine(Resources.ResetConfirmSuccess);
-                    }
-                    else
-                    {
-                        Console.WriteLine(Resources.ResetConfirmCancel);
-                    }
-
-                    Environment.Exit(0); // Suppress exit message
-                    break;
-                }
-
-                case "open":
-                {
-                    OpenSubOptions subOptions = (OpenSubOptions) _invokedVerbInstance;
-
-                    FileStore.Init(subOptions.Path);
-                    Process.Start(FileStore.GetRootPath());
-
-                    Environment.Exit(0); // Suppress exit message
-                    break;
-                }
-
-                case "users":
-                {
-                    UsersSubOptions subOptions = (UsersSubOptions) _invokedVerbInstance;
-
-                    FileStore.Init(subOptions.Path);
-                    Downloader downloader = new Downloader {UseCache = subOptions.Cache};
-                    UserScraper scraper = new UserScraper(downloader, subOptions.Count);
-
-                    scraper.ScrapeUsers();
-                    if (subOptions.Meta)
-                    {
-                        scraper.DownloadMetaData();
-                    }
-
-                    break;
-                }
-
-                case "projects":
-                {
-                    ProjectsSubOptions subOptions = (ProjectsSubOptions) _invokedVerbInstance;
-                    FileStore.Init(subOptions.Path);
-
-                    Downloader downloader = new Downloader {UseCache = subOptions.Cache};
-                    ProjectScraper scraper = new ProjectScraper(downloader);
-
-                    if (subOptions.Update)
-                    {
-                        scraper.UpdateProjectList();
-                    }
-                    if (subOptions.Download)
-                    {
-                        scraper.DownloadProjects();
-                    }
-
-                    break;
-                }
-
-                case "parse":
-                {
-                    ParseSubOptions subOptions = (ParseSubOptions) _invokedVerbInstance;
-                    FileStore.Init(subOptions.Path);
-
-                    CodeParser parser = new CodeParser();
-                    parser.WriteUsers();
-                    parser.WriteProjects();
-                    parser.WriteCode();
-
-                    break;
-                }
-
-                default:
-                {
-                    Environment.Exit(Parser.DefaultExitCodeFail);
-                    break;
-                }
-            }
-
-            // Exit message
+            
             Console.WriteLine("Done.");
         }
-    }
-
-
-    /// <summary>
-    ///     Main command-line options.
-    /// </summary>
-    internal class Options
-    {
-        [VerbOption("reset", HelpText = "Reset all files")]
-        public ResetSubOptions ResetSubOptions { get; set; }
-
-        [VerbOption("open", HelpText = "Opens the data folder in Windows Explorer")]
-        public OpenSubOptions OpenSubOptions { get; set; }
-
-        [VerbOption("users", HelpText = "Generate/update the list of users who most recently shared a project")]
-        public UsersSubOptions UsersSubOptions { get; set; }
-
-        [VerbOption("projects", HelpText = "Generate the list of projects of all registered users")]
-        public ProjectsSubOptions ProjectsSubOptions { get; set; }
-
-        [VerbOption("parse", HelpText = "Generate the list of projects of all registered users")]
-        public ParseSubOptions ParseSubOptions { get; set; }
-
-        [HelpOption]
-        public string GetUsage()
-        {
-            return HelpText.AutoBuild(this, current => HelpText.DefaultParsingErrorsHandler(this, current));
-        }
-
-        [HelpVerbOption]
-        public string GetUsage(string verb)
-        {
-            return HelpText.AutoBuild(this, verb);
-        }
-    }
-
-    /// <summary>
-    ///     Command-line options for all verbs interacting with the file system.
-    /// </summary>
-    internal abstract class FileSystemSharedOptions
-    {
-        [Option('p', "path", HelpText = "The path files should be read from and written to")]
-        public string Path { get; set; }
-
-        [Option('c', "cache", HelpText = "Enable caching; speeds up the process significantly")]
-        public bool Cache { get; set; }
-    }
-
-    /// <summary>
-    ///     Command-line options for the 'reset' verb.
-    /// </summary>
-    internal class ResetSubOptions : FileSystemSharedOptions
-    {
-    }
-
-    /// <summary>
-    ///     Command-line options for the 'open' verb.
-    /// </summary>
-    internal class OpenSubOptions : FileSystemSharedOptions
-    {
-    }
-
-    /// <summary>
-    ///     Command-line options for the 'users' verb.
-    /// </summary>
-    internal class UsersSubOptions : FileSystemSharedOptions
-    {
-        [Option('n', "number", DefaultValue = int.MaxValue, HelpText = "The number of users to scrape")]
-        public int Count { get; set; }
-
-        [Option('m', "meta", HelpText = "Download user meta-data")]
-        public bool Meta { get; set; }
-    }
-
-    /// <summary>
-    ///     Command-line options for the 'projects' verb.
-    /// </summary>
-    internal class ProjectsSubOptions : FileSystemSharedOptions
-    {
-        [Option('u', "update", HelpText = "Update the list of registered projects")]
-        public bool Update { get; set; }
-
-        [Option('d', "download", HelpText = "Download project code")]
-        public bool Download { get; set; }
-    }
-
-    /// <summary>
-    ///     Command-line options for the 'parse' verb.
-    /// </summary>
-    internal class ParseSubOptions : FileSystemSharedOptions
-    {
     }
 }


### PR DESCRIPTION
Instead of putting classes such as `OpenSubOptions` and `ResetSubOptions` as internal classes inside `Program`, these classes have been moved to their own namespace (`Kragle.ConsoleOptions`).

By adding a method (`Run`) to each of these classes, it is also no longer necessary to use a large switch statement inside `Program` to find out which verb was chosen by the user.
