### PR TITLE
Use 24h clock in log filename

### DIFF
--- a/Kragle/Kragle/Logger.cs
+++ b/Kragle/Kragle/Logger.cs
@@ -24,7 +24,7 @@ namespace Kragle
             FileStore.CreateDirectory(Resources.LogDirectory);
 
             string logFile = FileStore.GetAbsolutePath(Resources.LogDirectory,
-                string.Format("log_{0:yyyy-MM-dd hh-mm-ss}.log", DateTime.Now));
+                string.Format("log_{0:yyyy-MM-dd HH-mm-ss}.log", DateTime.Now));
             FileStream = new StreamWriter(logFile);
         }
 


### PR DESCRIPTION
Fixes a minor bug where the time in the filename was on a 12h scale instead of on a 24h scale (giving `03:14` instead of `15:14`).