### PR TITLE
Optional parsing

### DIFF
--- a/Kragle/Kragle/ConsoleOptions/DownloadSubOptions.cs
+++ b/Kragle/Kragle/ConsoleOptions/DownloadSubOptions.cs
@@ -1,0 +1,14 @@
+﻿using CommandLine;
+
+
+namespace Kragle.ConsoleOptions
+{
+    /// <summary>
+    ///     Command-line options for all verbs interacting with the Internet.
+    /// </summary>
+    public abstract class DownloadSubOptions : SubOptions
+    {
+        [Option('c', "cache", HelpText = "Enable caching; speeds up the process significantly")]
+        public bool Cache { get; set; }
+    }
+}

--- a/Kragle/Kragle/ConsoleOptions/ParseSubOptions.cs
+++ b/Kragle/Kragle/ConsoleOptions/ParseSubOptions.cs
@@ -1,10 +1,23 @@
-﻿namespace Kragle.ConsoleOptions
+﻿using CommandLine;
+
+
+namespace Kragle.ConsoleOptions
 {
     /// <summary>
     ///     Command-line options for the 'parse' verb.
     /// </summary>
     public class ParseSubOptions : SubOptions
     {
+        [Option('u', "users", HelpText = "Parse user data")]
+        public bool Users { get; set; }
+
+        [Option('p', "projects", HelpText = "Parse project data")]
+        public bool Projects { get; set; }
+
+        [Option('c', "code", HelpText = "Parse project code")]
+        public bool Code { get; set; }
+
+
         /// <summary>
         ///     Parses users, projects, and project code.
         /// </summary>
@@ -13,9 +26,18 @@
             FileStore.Init(Path);
 
             CodeParser parser = new CodeParser();
-            parser.WriteUsers();
-            parser.WriteProjects();
-            parser.WriteCode();
+            if (Users)
+            {
+                parser.WriteUsers();
+            }
+            if (Projects)
+            {
+                parser.WriteProjects();
+            }
+            if (Code)
+            {
+                parser.WriteCode();
+            }
         }
     }
 }

--- a/Kragle/Kragle/ConsoleOptions/ProjectsSubOptions.cs
+++ b/Kragle/Kragle/ConsoleOptions/ProjectsSubOptions.cs
@@ -6,7 +6,7 @@ namespace Kragle.ConsoleOptions
     /// <summary>
     ///     Command-line options for the 'projects' verb.
     /// </summary>
-    public class ProjectsSubOptions : SubOptions
+    public class ProjectsSubOptions : DownloadSubOptions
     {
         [Option('u', "update", HelpText = "Update the list of registered projects")]
         public bool Update { get; set; }

--- a/Kragle/Kragle/ConsoleOptions/SubOptions.cs
+++ b/Kragle/Kragle/ConsoleOptions/SubOptions.cs
@@ -11,9 +11,6 @@ namespace Kragle.ConsoleOptions
         [Option('o', "output", HelpText = "The path files should be read from and written to")]
         public string Path { get; set; }
 
-        [Option('c', "cache", HelpText = "Enable caching; speeds up the process significantly")]
-        public bool Cache { get; set; }
-
 
         /// <summary>
         ///     Executes the action corresponding to this sub-option.

--- a/Kragle/Kragle/ConsoleOptions/UsersSubOptions.cs
+++ b/Kragle/Kragle/ConsoleOptions/UsersSubOptions.cs
@@ -6,7 +6,7 @@ namespace Kragle.ConsoleOptions
     /// <summary>
     ///     Command-line options for the 'users' verb.
     /// </summary>
-    public class UsersSubOptions : SubOptions
+    public class UsersSubOptions : DownloadSubOptions
     {
         [Option('n', "number", HelpText = "The number of users to scrape", DefaultValue = int.MaxValue)]
         public int Count { get; set; }

--- a/Kragle/Kragle/Kragle.csproj
+++ b/Kragle/Kragle/Kragle.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Archiver.cs" />
     <Compile Include="CodeParser.cs" />
     <Compile Include="ConsoleOptions\ArchiveSubOptions.cs" />
+    <Compile Include="ConsoleOptions\DownloadSubOptions.cs" />
     <Compile Include="ConsoleOptions\ExtractSubOptions.cs" />
     <Compile Include="ConsoleOptions\ParseSubOptions.cs" />
     <Compile Include="ConsoleOptions\SubOptions.cs" />


### PR DESCRIPTION
* Adds functionality to parse only the selected parts of the data: users, projects, or code.
* Instead of having all `SubOptions` classes inherit directly from `SubOptions`, some classes now extend from `DownloadSubOptions` (which in turn inherits from `SubOptions` anyway). This way, the options related to downloading are only available in the options that actually download data.
